### PR TITLE
feat(send): Send & Draft email endpoints (US1+US2+US3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,5 @@ PROJECT_PLAN.md
 
 ### Spec files
 specs
+.claude
+.specify

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ A robust, enterprise-ready Spring Boot application for Gmail management with exc
 - **🏷️ Label Operations**: Bulk label modification and management
 - **📖 Message Content**: Extract and display email body content
 - **📚 Bulk Operations**: Mass delete and label operations with validation
+- **📨 Send & Draft Operations**: Create drafts for human review, send approved drafts programmatically, or direct-send trusted templates — all via Bearer token or OAuth2 session
+- **🛡️ Header Injection Prevention**: CRLF-injection rejected as a security event distinct from validation errors, with per-field positional reporting on recipient lists
 - **⚡ Native Batch Processing**: Gmail API native batchDelete() for up to 1000 messages per batch (99% quota reduction)
 - **🚀 High-Performance Operations**: Adaptive batch sizing with circuit breaker protection
 - **🔄 Intelligent Rate Limiting**: Exponential backoff with adaptive algorithms
@@ -118,6 +120,9 @@ Gmail Buddy supports **dual authentication modes**:
 | `PUT` | `/api/v1/gmail/messages/{id}/read` | Mark message as read | - | Standard |
 | `DELETE` | `/api/v1/gmail/messages/filter` | **High-performance bulk delete** | `FilterCriteriaDTO` | **99% quota reduction** |
 | `POST` | `/api/v1/gmail/messages/filter/modifyLabels` | Bulk modify labels | `FilterCriteriaWithLabelsDTO` | Batch optimized |
+| `POST` | `/api/v1/gmail/drafts` | **Stage a draft for review** in Gmail Drafts folder | `SendMessageDTO` | Standard (10 quota units) |
+| `POST` | `/api/v1/gmail/drafts/{draftId}/send` | **Send a previously-created draft** programmatically | - | Standard (100 quota units, naturally idempotent) |
+| `POST` | `/api/v1/gmail/messages` | **Send a message directly** without staging (trusted templates only) | `SendMessageDTO` | Standard (100 quota units) |
 
 ### High-Performance Batch Operations
 
@@ -181,7 +186,26 @@ curl -X POST http://localhost:8020/api/v1/gmail/messages/filter/modifyLabels \
   }'
 ```
 
-> **Note**: Replace `ya29.a0ARrdaM...` with your actual Bearer token. See [API Testing Guide](docs/API_TESTING_GUIDE.md) for instructions on obtaining tokens.
+**Create a Draft (stage for review before sending):**
+```bash
+curl -i -X POST http://localhost:8020/api/v1/gmail/drafts \
+  -H "Authorization: Bearer ya29.a0ARrdaM..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": ["recipient@example.com"],
+    "subject": "Following up on our conversation",
+    "body": "<p>Hi,</p><p>This draft was created via the Gmail Buddy API.</p>",
+    "bodyType": "html"
+  }'
+
+# Response (201 Created):
+# {"draftId":"r-9876543210","messageId":"19a2b3c4d5e6f7g8","threadId":"19a2b3c4d5e6f7g8","status":"DRAFT"}
+#
+# The draft is immediately visible in Gmail → Drafts folder for review, edit, or discard.
+# To send it programmatically: POST /api/v1/gmail/drafts/{draftId}/send
+```
+
+> **Note**: Replace `ya29.a0ARrdaM...` with your actual Bearer token. The token must carry the `gmail.send` scope (or `gmail.modify` / `mail.google.com`) for send and draft endpoints. See [API Testing Guide](docs/API_TESTING_GUIDE.md) for instructions on obtaining tokens.
 
 ### Error Responses
 
@@ -626,8 +650,8 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 **Insufficient Gmail Permissions**
 - Check that Gmail API is enabled in Google Cloud Console
-- Verify OAuth2 scopes include `gmail.readonly` and `gmail.modify`
-- Re-authenticate to refresh token permissions
+- Verify OAuth2 scopes include `gmail.readonly`, `gmail.modify`, and `gmail.send` (required for send and draft endpoints)
+- Re-authenticate to refresh token permissions (note: adding `gmail.send` to the scope set invalidates existing refresh tokens; re-consent is required on first startup after this scope is added)
 
 **Test User Restrictions**
 - Add your Google account as a test user in OAuth consent screen

--- a/docs/API_TESTING_GUIDE.md
+++ b/docs/API_TESTING_GUIDE.md
@@ -33,7 +33,7 @@ The easiest way to get a Bearer token for API testing:
 
 2. **Configure Scopes**
    - In the left panel, find "Input your own scopes"
-   - Enter: `https://mail.google.com/`
+   - Enter: `https://mail.google.com/` (covers all endpoints), or enter `https://www.googleapis.com/auth/gmail.send` if you only need to test the send/draft endpoints
    - Click "Authorize APIs"
 
 3. **Complete OAuth Flow**
@@ -89,6 +89,9 @@ Gmail Buddy currently uses three Gmail scopes. **Which scope you need depends on
 | `POST /messages/filter/modifyLabels` | `https://www.googleapis.com/auth/gmail.modify` |
 | `DELETE /messages/{id}` | `https://mail.google.com/` |
 | `DELETE /messages/filter` (bulk) | `https://mail.google.com/` |
+| `POST /drafts` | `https://www.googleapis.com/auth/gmail.send` |
+| `POST /drafts/{draftId}/send` | `https://www.googleapis.com/auth/gmail.send` |
+| `POST /messages` (direct send) | `https://www.googleapis.com/auth/gmail.send` |
 
 ### Why the DELETE endpoints require `https://mail.google.com/`
 
@@ -108,7 +111,7 @@ If those constraints become a blocker, the alternative is to rewrite the DELETE 
 
 ### Recommended scope for testing the full API
 
-To exercise every current endpoint with a single token, request `https://mail.google.com/` in the OAuth Playground (instructions above). It implicitly covers `gmail.readonly` and `gmail.modify` as well. If you only intend to test read or modify endpoints, you can use the narrower `gmail.readonly` or `gmail.modify` scope and skip the restricted-scope warning entirely.
+To exercise every current endpoint with a single token, request `https://mail.google.com/` in the OAuth Playground (instructions above). It implicitly covers `gmail.readonly`, `gmail.modify`, and `gmail.send` as well. If you only intend to test the new send/draft endpoints (`POST /drafts`, `POST /drafts/{draftId}/send`, `POST /messages`), you can use the narrower `https://www.googleapis.com/auth/gmail.send` scope — this avoids requesting the restricted `mail.google.com` scope entirely. If you only intend to test read or modify endpoints, use `gmail.readonly` or `gmail.modify` accordingly.
 
 ## 🔧 Postman Setup
 
@@ -245,6 +248,47 @@ curl -X DELETE http://localhost:8020/api/v1/gmail/messages/filter \
     "from": "oldnewsletter@example.com",
     "query": "older_than:1y"
   }'
+```
+
+### Send & Draft Operations
+
+**Create a Draft** (recommended path for AI-personalized outreach)
+```bash
+curl -i -X POST http://localhost:8020/api/v1/gmail/drafts \
+  -H "Authorization: Bearer ya29.a0ARrdaM..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": ["recruiter@example.com"],
+    "subject": "Application for Senior Backend Engineer",
+    "body": "<p>Dear hiring team,</p><p>I am reaching out about the role...</p>",
+    "bodyType": "html"
+  }'
+# Returns 201 Created with Location header and {"draftId":"...","messageId":"...","threadId":"...","status":"DRAFT"}
+```
+
+**Send an Existing Draft** (state transition — 200, not 201)
+```bash
+DRAFT_ID="r-9876543210"   # draftId from the POST /drafts response
+
+curl -i -X POST "http://localhost:8020/api/v1/gmail/drafts/$DRAFT_ID/send" \
+  -H "Authorization: Bearer ya29.a0ARrdaM..."
+# Returns 200 OK with {"messageId":"...","threadId":"...","status":"SENT"}
+# A retry after successful send returns 404 (natural idempotency)
+```
+
+**Send Directly** (deterministic templates only — no draft created)
+```bash
+curl -i -X POST http://localhost:8020/api/v1/gmail/messages \
+  -H "Authorization: Bearer ya29.a0ARrdaM..." \
+  -H "Content-Type: application/json" \
+  -d '{
+    "to": ["recruiter@example.com"],
+    "subject": "Following up on our conversation",
+    "body": "Hi,\n\nThanks for taking the time to chat.\n\nBest,\nOmar",
+    "bodyType": "text"
+  }'
+# Returns 201 Created with Location header and {"messageId":"...","threadId":"...","status":"SENT"}
+# WARNING: Do not auto-retry after a network timeout — duplicate sends may result.
 ```
 
 ## 🚨 Troubleshooting

--- a/docs/FOLLOW_UPS.md
+++ b/docs/FOLLOW_UPS.md
@@ -60,6 +60,26 @@ Per CLAUDE.md §A3 (Anti-Slop "No Cosmetic-Only Changes"): do NOT bundle this wi
 
 ---
 
+## FU-003 — `ValidationException` returns HTTP 400 instead of 422
+
+**Surfaces as**: contract drift between `specs/001-send-draft-emails/contracts/api-endpoints.md` (Endpoint 1 error matrix says `400 invalidArgument` from Gmail → `/problems/invalid-recipient` → HTTP **422 Unprocessable Entity**) and the actual production response, which returns HTTP **400 Bad Request**.
+
+Origin: `ValidationException.getHttpStatus()` returns 400 (used by all Bean Validation failures). When the send-message Gmail-error mapping helper (`mapGmailSendError`) wraps a Gmail-side `invalidArgument` rejection into `ValidationException`, `GlobalExceptionHandler.handleValidationException` resolves the status to 400 — same as a generic input-validation failure. The contract intends 422 for the semantic-rejection-by-mailbox-provider case, distinguishable from 400 for malformed request input.
+
+**Why it's not blocking**: the response is still actionable for the calling service — the ProblemDetail `type` URI distinguishes `/problems/invalid-recipient` from `/problems/validation-error`, so a sophisticated client can branch correctly. But the HTTP status semantics don't match the contract.
+
+**Recommended fix**:
+- Add a new `InvalidRecipientException extends GmailBuddyClientException` with `getHttpStatus() = 422`.
+- Update `GmailRepositoryImpl.mapGmailSendError(...)` to throw `InvalidRecipientException` (instead of `ValidationException`) for the `invalidArgument` case from Gmail's send/draft endpoints.
+- Add a dedicated `@ExceptionHandler(InvalidRecipientException.class)` branch in `GlobalExceptionHandler` returning 422 + `/problems/invalid-recipient`.
+- Update the SendMessageControllerTest assertion to expect 422 (currently asserts 400 to match observed behavior).
+
+**Recommended timing**: small follow-up commit on the same branch IF you want the contract to match before merging. Otherwise a focused follow-up PR after merge — the test asserts current behavior so this isn't a regression.
+
+**Owner (per CLAUDE.md)**: `validation-error-handler` (exception hierarchy + GlobalExceptionHandler) with light coordination from `gmail-api-integration` (the mapGmailSendError helper).
+
+---
+
 ## How to use this doc
 
 - Add new entries as `FU-NNN` sequentially.

--- a/docs/FOLLOW_UPS.md
+++ b/docs/FOLLOW_UPS.md
@@ -1,0 +1,67 @@
+# Follow-ups
+
+Pre-existing items observed during other work that belong on the backlog. Each is documented with: where it surfaces, why it's not blocking, recommended fix, and recommended timing/branch.
+
+---
+
+## FU-001 — Configure persistent encryption key for `TokenReferenceService`
+
+**Surfaces as**: startup log entry every time the application boots:
+
+```
+WARN  - No encryption key configured. Generating temporary key for session.
+       Configure 'app.security.token.encryption-key' for production use.
+INFO  - AESEncryptionUtil initialized with secure key
+```
+
+Origin: `TokenReferenceService` / `AESEncryptionUtil` (added in the Token Security feature, PR #6).
+
+**Why it's not blocking**: token references are created per request and consumed within the same request lifecycle, so an ephemeral per-startup key still functions correctly for token-validation purposes. The risk is **operational, not functional**: any deployment that survives across process restarts (e.g., a daemon, a server, or even a long-lived local instance you don't want to re-authenticate to) sees its in-memory token-reference cache become unreadable on restart, so subsequent requests using cached references would fail until the cache is rebuilt.
+
+**Recommended fix**:
+- Add `app.security.token.encryption-key` to `.env.example` with a placeholder.
+- Document the format requirement (likely an AES-256 key — verify in `AESEncryptionUtil`).
+- Document a generation recipe (e.g., `openssl rand -base64 32`).
+- Update the production deployment runbook (when one exists) to require this key be set.
+- Consider whether to fail-fast on missing key in non-`dev` profiles, vs. the current warn-and-continue behavior.
+
+**Recommended timing**: separate small PR after the send/draft feature (`001-send-draft-emails`) merges. Out of scope for that branch per spec § Out of Scope (operational hardening is its own concern).
+
+**Owner (per CLAUDE.md)**: `security-auth-specialist` (token security domain) + `spring-boot-config-manager` (the `.env` / `application.properties` plumbing).
+
+---
+
+## FU-002 — Resolve Spring `@Autowired` warning on `WebConfig`
+
+**Surfaces as**: startup log entry every time the application boots:
+
+```
+WARN - Inconsistent constructor declaration on bean with name 'webConfig':
+       single autowire-marked constructor flagged as optional - this constructor
+       is effectively required since there is no default constructor to fall
+       back to: public com.aucontraire.gmailbuddy.config.WebConfig$$SpringCGLIB$$0(
+         com.aucontraire.gmailbuddy.config.RateLimitInterceptor)
+```
+
+Origin: pre-existing in `WebConfig.java`. Likely an `@Autowired(required = false)` (or equivalent default-arg pattern) on a constructor that has no fallback default constructor — Spring's warning says: "you marked this optional but I can't actually skip it because there's no other constructor."
+
+**Why it's not blocking**: cosmetic. The bean is constructed correctly; the warning is just noise on every startup.
+
+**Recommended fix** (one of):
+- Remove the `@Autowired` annotation entirely if the constructor is the only one (Spring auto-detects single-constructor injection since 4.3 — explicit annotation is redundant).
+- Or, if `@Autowired(required = false)` was intentional, refactor the constructor to truly support optional injection (e.g., add a default constructor or a no-arg path).
+- Most likely fix: drop the annotation; net change ≈ 1 line.
+
+**Recommended timing**: trivial 1-line commit. Could go in any small docs/cleanup PR (e.g., bundled with the FU-001 fix, or as a one-off chore commit).
+
+Per CLAUDE.md §A3 (Anti-Slop "No Cosmetic-Only Changes"): do NOT bundle this with feature work. Cosmetic-only changes belong in their own commit so feature diffs stay clean.
+
+**Owner (per CLAUDE.md)**: `spring-boot-config-manager` (Spring DI / configuration domain).
+
+---
+
+## How to use this doc
+
+- Add new entries as `FU-NNN` sequentially.
+- Each entry stays open until the corresponding fix lands; on completion, mark the heading as `~~FU-NNN~~ (resolved in <commit-sha>)` and move to the bottom of the file.
+- Items here are intentionally NOT the same scope as feature spec backlogs (which live under `specs/`); these are cross-cutting nits / operational items / pre-existing tech debt observed during feature work.

--- a/docs/FOLLOW_UPS.md
+++ b/docs/FOLLOW_UPS.md
@@ -80,6 +80,40 @@ Origin: `ValidationException.getHttpStatus()` returns 400 (used by all Bean Vali
 
 ---
 
+## FU-004 — Existing `getMessageBody` log statement leaks message body content
+
+**Surfaces as**: a constitution VII violation in pre-existing code, discovered during the T062 spot-check of the send/draft feature's deviation. Not introduced by the send/draft feature, but it's the same kind of issue the deviation is bounded against.
+
+**Location**: `src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java`, line 317:
+
+```java
+logger.info("Message retrieved: {}", message.toPrettyString());
+```
+
+`message.toPrettyString()` serializes the entire Gmail API `Message` object including `payload` → `parts` → `body.data` (base64-encoded body content). This means the existing `GET /api/v1/gmail/messages/{messageId}/body` endpoint logs full email body content on every call.
+
+**Why it's a violation**: Constitution Principle VII states *"OAuth tokens, credentials, email bodies, and PII MUST NOT appear in logs."* The body content of every retrieved message is being logged.
+
+**Why it wasn't blocking the send/draft feature**: this is in a DIFFERENT endpoint (the existing message-retrieval path), not in any new send/draft endpoint. The new code we added doesn't log body content. Per CLAUDE.md §A3 ("No Cosmetic-Only Changes" mixed with feature work), this fix belongs in its own commit/PR.
+
+**Recommended fix** (1 line):
+
+```java
+// Before
+logger.info("Message retrieved: {}", message.toPrettyString());
+
+// After
+logger.info("Message retrieved: messageId={}", message.getId());
+```
+
+Optionally also log `getThreadId()` if useful for diagnostics. Do NOT log `toPrettyString()`, `getPayload()`, or anything that traverses to body content.
+
+**Recommended timing**: trivial 1-line follow-up commit. Could be bundled with FU-002 (cosmetic Spring `@Autowired` warning fix) into one tiny chore commit since both are pre-existing-code hygiene.
+
+**Owner (per CLAUDE.md)**: `gmail-api-integration` (Gmail API path) or `security-auth-specialist` (logging-PII concern). Either is appropriate.
+
+---
+
 ## How to use this doc
 
 - Add new entries as `FU-NNN` sequentially.

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
             <artifactId>google-api-services-gmail</artifactId>
             <version>v1-rev20240520-2.0.0</version>
         </dependency>
+        <!-- Jakarta Mail (Eclipse Angus reference implementation) for MimeMessage construction.
+             Version omitted — Spring Boot 3.4.0 BOM manages org.eclipse.angus:jakarta.mail at 2.0.3. -->
+        <dependency>
+            <groupId>org.eclipse.angus</groupId>
+            <artifactId>jakarta.mail</artifactId>
+        </dependency>
         <dependency>
             <groupId>com.google.http-client</groupId>
             <artifactId>google-http-client-jackson2</artifactId>

--- a/src/main/java/com/aucontraire/gmailbuddy/config/GmailBuddyProperties.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/config/GmailBuddyProperties.java
@@ -2,6 +2,7 @@ package com.aucontraire.gmailbuddy.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.bind.DefaultValue;
+import org.springframework.util.unit.DataSize;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.Valid;
@@ -28,7 +29,8 @@ public record GmailBuddyProperties(
     @Valid @NotNull Validation validation,
     @Valid @NotNull Security security,
     @Valid @NotNull Environment environment,
-    @Valid @NotNull ApplicationRateLimit applicationRateLimit
+    @Valid @NotNull ApplicationRateLimit applicationRateLimit,
+    @Valid @NotNull Send send
 ) {
 
     /**
@@ -245,6 +247,18 @@ public record GmailBuddyProperties(
     public record ApplicationRateLimit(
         @Min(1) @Max(10000) int requestsPerWindow,
         @Min(1) @Max(3600) long windowSizeSeconds
+    ) {
+        // Default values are set in application.properties
+    }
+
+    /**
+     * Send and draft endpoint configuration.
+     * Maps to gmail-buddy.send.* properties.
+     */
+    public record Send(
+        @NotNull DataSize maxBodySize,
+        @Min(1) @Max(500) int maxRecipientsPerMessage,
+        @Min(1) @Max(998) int maxSubjectLength
     ) {
         // Default values are set in application.properties
     }

--- a/src/main/java/com/aucontraire/gmailbuddy/config/RateLimitInterceptor.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/config/RateLimitInterceptor.java
@@ -122,6 +122,15 @@ public class RateLimitInterceptor implements HandlerInterceptor {
             // DELETE /messages/filter - batch delete
             // Estimate for a moderate batch (10 batches of 50 messages each)
             return quotaEstimator.estimateBatchDeleteQuota(500, 50);
+        } else if (uri.endsWith("/messages") && "POST".equals(method)) {
+            // POST /messages - direct send
+            return quotaEstimator.estimateSendMessageQuota();
+        } else if (uri.endsWith("/drafts") && "POST".equals(method)) {
+            // POST /drafts - create draft
+            return quotaEstimator.estimateCreateDraftQuota();
+        } else if (uri.matches(".*/drafts/[^/]+/send") && "POST".equals(method)) {
+            // POST /drafts/{draftId}/send - send existing draft
+            return quotaEstimator.estimateSendDraftQuota();
         } else if (uri.endsWith("/messages") || uri.endsWith("/messages/latest")) {
             // GET /messages or /messages/latest - list messages
             return quotaEstimator.estimateListMessagesQuota(0); // Can't know count yet

--- a/src/main/java/com/aucontraire/gmailbuddy/config/TokenAuthenticationFilter.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/config/TokenAuthenticationFilter.java
@@ -97,7 +97,8 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
                 // SECURITY FIX: Create encrypted token reference instead of storing raw token
                 TokenReference tokenReference = tokenReferenceService.createTokenReference(
                     bearerToken,
-                    userEmail
+                    userEmail,
+                    tokenInfo.getScope()
                 );
 
                 // Store only the secure reference ID, not the raw token

--- a/src/main/java/com/aucontraire/gmailbuddy/constants/ProblemTypes.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/constants/ProblemTypes.java
@@ -76,6 +76,37 @@ public final class ProblemTypes {
      */
     public static final String CONSTRAINT_VIOLATION = BASE_URI + "/constraint-violation";
 
+    // Send & Draft endpoints (feature 001)
+
+    /**
+     * Header injection detected - a header-bound field contains carriage-return or
+     * line-feed characters, indicating a header-injection attempt.
+     * HTTP Status: 400 Bad Request
+     * Distinct from /problems/validation-error so security-relevant attempts can be
+     * triaged separately from ordinary input validation failures (FR-015, FR-018).
+     * Example: Subject or recipient address contains \r or \n.
+     */
+    public static final String HEADER_INJECTION_DETECTED = BASE_URI + "/header-injection-detected";
+
+    /**
+     * Invalid recipient - Gmail rejected one or more recipient addresses as invalid.
+     * HTTP Status: 422 Unprocessable Entity
+     * Triggered when Gmail returns 400 invalidArgument for a recipient address that
+     * passed local validation but was rejected by the upstream mail provider (FR-018).
+     * Example: Address is syntactically plausible but the mailbox does not exist.
+     */
+    public static final String INVALID_RECIPIENT = BASE_URI + "/invalid-recipient";
+
+    /**
+     * Daily send limit exceeded - the authenticated user has reached their Gmail
+     * daily sending limit (Google returns 403 dailySendLimitExceeded).
+     * HTTP Status: 429 Too Many Requests
+     * Response includes Retry-After: 86400 (24-hour window reset).
+     * Must NOT be routed through any application-level retry-with-backoff path (FR-019).
+     * Example: User has exhausted their daily outbound message quota.
+     */
+    public static final String DAILY_SEND_LIMIT_EXCEEDED = BASE_URI + "/daily-send-limit-exceeded";
+
     // Server Error Problem Types (5xx)
 
     /**
@@ -84,6 +115,18 @@ public final class ProblemTypes {
      * Example: Gmail API is down, network timeout, API error response.
      */
     public static final String GMAIL_API_ERROR = BASE_URI + "/gmail-api-error";
+
+    // Send & Draft endpoints (feature 001)
+
+    /**
+     * Message send failed - Gmail rejected or failed to process a send/draft-send
+     * request for a reason not covered by a more specific problem type.
+     * HTTP Status: 502 Bad Gateway
+     * Catch-all for MessageSendException cases that do not map to INVALID_RECIPIENT
+     * or DAILY_SEND_LIMIT_EXCEEDED (FR-018).
+     * Example: Transient Gmail API failure, unexpected error response from provider.
+     */
+    public static final String MESSAGE_SEND_FAILED = BASE_URI + "/message-send-failed";
 
     /**
      * Service unavailable - the Gmail Buddy service is temporarily unavailable.

--- a/src/main/java/com/aucontraire/gmailbuddy/controller/GmailController.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/controller/GmailController.java
@@ -4,15 +4,18 @@ import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
 import com.aucontraire.gmailbuddy.dto.DeleteResult;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaDTO;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaWithLabelsDTO;
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
 import com.aucontraire.gmailbuddy.dto.common.ResponseMetadata;
 import com.aucontraire.gmailbuddy.dto.error.ErrorResponse;
 import com.aucontraire.gmailbuddy.dto.response.BulkDeleteResponse;
 import com.aucontraire.gmailbuddy.dto.response.DeleteOperationResult;
+import com.aucontraire.gmailbuddy.dto.response.DraftResponse;
 import com.aucontraire.gmailbuddy.dto.response.LabelModificationResponse;
 import com.aucontraire.gmailbuddy.dto.response.MessageListResponse;
 import com.aucontraire.gmailbuddy.dto.response.MessageSummary;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
 import com.aucontraire.gmailbuddy.service.BulkOperationResult;
+import com.aucontraire.gmailbuddy.service.DraftCreationResult;
 import com.aucontraire.gmailbuddy.service.GmailService;
 import com.aucontraire.gmailbuddy.service.MessageListResult;
 import com.aucontraire.gmailbuddy.util.LinkHeaderBuilder;
@@ -38,6 +41,7 @@ import org.springframework.security.oauth2.client.authentication.OAuth2Authentic
 import org.springframework.web.bind.annotation.*;
 import jakarta.validation.Valid;
 
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -397,6 +401,57 @@ public class GmailController {
         );
 
         return ResponseEntity.ok(response);
+    }
+
+    /**
+     * POST /drafts - Stage an email as a draft in the user's Gmail Drafts folder.
+     *
+     * <p>This is the default outreach path for AI-personalized content. The draft is
+     * immediately visible in any Gmail client (web, mobile, desktop) for the user to
+     * review, edit, send, or discard before delivery.</p>
+     *
+     * <p>The same {@link SendMessageDTO} payload is used for both direct-send and
+     * draft-creation; the destination Gmail API call differs. Per the API contract,
+     * this endpoint returns HTTP 201 Created with a {@code Location} header pointing
+     * to the new draft resource.</p>
+     */
+    @Operation(
+        summary = "Create a draft email",
+        description = "Stages an email as a draft in the user's Gmail Drafts folder. " +
+                      "The draft is immediately visible in Gmail for review, editing, or discard. " +
+                      "This is the recommended path for AI-personalized outreach content. " +
+                      "Returns HTTP 201 Created with a Location header pointing to the new draft."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "Draft created successfully",
+            content = @Content(schema = @Schema(implementation = DraftResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid request - validation failure or header-injection detected",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - invalid or missing authentication",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient Gmail permissions",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "422", description = "Unprocessable entity - Gmail rejected one or more recipient addresses",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "502", description = "Gmail API error - draft creation failed",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping(value = "/drafts",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<DraftResponse> createDraft(
+            @Valid @RequestBody SendMessageDTO dto) {
+
+        String userId = properties.gmailApi().defaultUserId();
+
+        DraftCreationResult result = gmailService.createDraft(userId, dto);
+
+        logger.info("Draft created for userId={}, draftId={}", userId, result.draftId());
+
+        DraftResponse body = DraftResponse.drafted(result.draftId(), result.messageId(), result.threadId());
+        URI location = URI.create("/api/v1/gmail/drafts/" + result.draftId());
+
+        return ResponseEntity.created(location).body(body);
     }
 
     @Operation(

--- a/src/main/java/com/aucontraire/gmailbuddy/controller/GmailController.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/controller/GmailController.java
@@ -448,7 +448,10 @@ public class GmailController {
 
         DraftCreationResult result = gmailService.createDraft(userId, dto);
 
-        logger.info("Draft created for userId={}, draftId={}", userId, result.draftId());
+        logger.info("Draft created: userId={}, draftId={}, recipientCount={}, to={}, cc={}, bcc={}, subject={}",
+                userId, result.draftId(),
+                dto.to().size() + dto.cc().size() + dto.bcc().size(),
+                dto.to(), dto.cc(), dto.bcc(), dto.subject());
 
         DraftResponse body = DraftResponse.drafted(result.draftId(), result.messageId(), result.threadId());
         URI location = URI.create("/api/v1/gmail/drafts/" + result.draftId());
@@ -548,7 +551,10 @@ public class GmailController {
 
         SentMessageResult result = gmailService.sendMessage(userId, dto);
 
-        logger.info("Message sent for userId={}, messageId={}", userId, result.messageId());
+        logger.info("Message sent: userId={}, messageId={}, recipientCount={}, to={}, cc={}, bcc={}, subject={}",
+                userId, result.messageId(),
+                dto.to().size() + dto.cc().size() + dto.bcc().size(),
+                dto.to(), dto.cc(), dto.bcc(), dto.subject());
 
         URI location = URI.create("/api/v1/gmail/messages/" + result.messageId() + "/body");
         return ResponseEntity.created(location).body(SendMessageResponse.sent(result.messageId(), result.threadId()));

--- a/src/main/java/com/aucontraire/gmailbuddy/controller/GmailController.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/controller/GmailController.java
@@ -11,6 +11,7 @@ import com.aucontraire.gmailbuddy.dto.response.BulkDeleteResponse;
 import com.aucontraire.gmailbuddy.dto.response.DeleteOperationResult;
 import com.aucontraire.gmailbuddy.dto.response.DraftResponse;
 import com.aucontraire.gmailbuddy.dto.response.LabelModificationResponse;
+import com.aucontraire.gmailbuddy.dto.response.SendMessageResponse;
 import com.aucontraire.gmailbuddy.dto.response.MessageListResponse;
 import com.aucontraire.gmailbuddy.dto.response.MessageSummary;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
@@ -18,6 +19,7 @@ import com.aucontraire.gmailbuddy.service.BulkOperationResult;
 import com.aucontraire.gmailbuddy.service.DraftCreationResult;
 import com.aucontraire.gmailbuddy.service.GmailService;
 import com.aucontraire.gmailbuddy.service.MessageListResult;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
 import com.aucontraire.gmailbuddy.util.LinkHeaderBuilder;
 import com.google.api.services.gmail.model.Message;
 import io.swagger.v3.oas.annotations.Operation;
@@ -452,6 +454,104 @@ public class GmailController {
         URI location = URI.create("/api/v1/gmail/drafts/" + result.draftId());
 
         return ResponseEntity.created(location).body(body);
+    }
+
+    /**
+     * POST /drafts/{draftId}/send — Deliver a previously-staged draft.
+     *
+     * <p>Triggers immediate delivery of the draft identified by {@code draftId}.
+     * This is a state transition on an existing draft resource, not creation,
+     * so the response is HTTP 200 OK with no {@code Location} header (per
+     * Decision 3 / contracts/api-endpoints.md Endpoint 3).</p>
+     *
+     * <p>Naturally idempotent: a successful send removes the draft from Gmail.
+     * A retry returns HTTP 404 because the draft no longer exists (see Decision 6).</p>
+     */
+    @Operation(
+        summary = "Send an existing draft",
+        description = "Delivers a previously-created draft by its identifier. " +
+                      "This is a state transition on an existing resource — the draft is consumed " +
+                      "and the message appears in the Sent folder. " +
+                      "Returns HTTP 200 OK (not 201) with no Location header. " +
+                      "Naturally idempotent: a retry after successful send returns 404."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Draft sent successfully",
+            content = @Content(schema = @Schema(implementation = SendMessageResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - invalid or missing authentication",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Draft not found - already sent, discarded, or invalid draftId",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "429", description = "Daily Gmail send limit reached - retry after 86400 seconds",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "502", description = "Gmail API error - send failed",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping(value = "/drafts/{draftId}/send",
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<SendMessageResponse> sendDraft(
+            @Parameter(description = "The Gmail-assigned draft identifier returned by POST /drafts", required = true)
+            @PathVariable String draftId) {
+
+        String userId = properties.gmailApi().defaultUserId();
+
+        SentMessageResult result = gmailService.sendDraft(userId, draftId);
+
+        logger.info("Draft sent for userId={}, draftId={}, messageId={}", userId, draftId, result.messageId());
+
+        return ResponseEntity.ok(SendMessageResponse.sent(result.messageId(), result.threadId()));
+    }
+
+    /**
+     * POST /messages — Send an email message immediately.
+     *
+     * <p>Sends the message constructed from the request body directly via the Gmail
+     * API. Reserved for deterministic, pre-trusted templates. Per Decision 3 and
+     * contracts/api-endpoints.md Endpoint 1, this returns HTTP 201 Created with a
+     * {@code Location} header pointing to the body-fetch endpoint for the new
+     * message resource.</p>
+     *
+     * <p><strong>At-least-once semantics</strong>: callers MUST NOT auto-retry
+     * after a network timeout — duplicate sends may result (Decision 6, FR-023).</p>
+     */
+    @Operation(
+        summary = "Send an email message directly",
+        description = "Sends an email immediately via the Gmail API. " +
+                      "Reserved for deterministic, pre-trusted templates — not the recommended path for " +
+                      "AI-personalized content (use POST /drafts instead). " +
+                      "Returns HTTP 201 Created with a Location header pointing to the message body endpoint. " +
+                      "WARNING: callers must not auto-retry after a timeout — duplicate sends may result."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "Message sent successfully — new message resource created",
+            content = @Content(schema = @Schema(implementation = SendMessageResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid request - validation failure or header-injection detected",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - invalid or missing authentication",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient Gmail permissions or unverified send-as identity",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "422", description = "Unprocessable entity - Gmail rejected one or more recipient addresses",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "429", description = "Daily Gmail send limit reached - retry after 86400 seconds",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "502", description = "Gmail API error - send failed",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PostMapping(value = "/messages",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<SendMessageResponse> sendMessage(
+            @Valid @RequestBody SendMessageDTO dto) {
+
+        String userId = properties.gmailApi().defaultUserId();
+
+        SentMessageResult result = gmailService.sendMessage(userId, dto);
+
+        logger.info("Message sent for userId={}, messageId={}", userId, result.messageId());
+
+        URI location = URI.create("/api/v1/gmail/messages/" + result.messageId() + "/body");
+        return ResponseEntity.created(location).body(SendMessageResponse.sent(result.messageId(), result.threadId()));
     }
 
     @Operation(

--- a/src/main/java/com/aucontraire/gmailbuddy/dto/SendMessageDTO.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/dto/SendMessageDTO.java
@@ -1,0 +1,81 @@
+package com.aucontraire.gmailbuddy.dto;
+
+import com.aucontraire.gmailbuddy.validation.MaxBodySize;
+import com.aucontraire.gmailbuddy.validation.NoHeaderInjection;
+import com.aucontraire.gmailbuddy.validation.OptionalEmail;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+/**
+ * Request DTO for both the direct-send ({@code POST /api/v1/gmail/messages}) and
+ * draft-creation ({@code POST /api/v1/gmail/drafts}) endpoints.
+ *
+ * <p>The same payload shape serves both endpoints; the difference is which Gmail
+ * API method the service layer invokes. See spec.md § User Story 1 and § User
+ * Story 3 for the rationale.</p>
+ *
+ * <h2>Validation rules</h2>
+ * <ul>
+ *   <li>{@code to} — required, 1–500 elements, each element must be a valid
+ *       (non-blank) email address that contains no CRLF characters (FR-009,
+ *       FR-010, FR-011, FR-015).</li>
+ *   <li>{@code cc}, {@code bcc} — optional, default {@code []}, max 500 elements;
+ *       each element is validated the same way as {@code to} elements (FR-010,
+ *       FR-015).</li>
+ *   <li>{@code subject} — required, max 998 characters (RFC 5322 single-header
+ *       limit), no CRLF characters (FR-012, FR-015).</li>
+ *   <li>{@code body} — required, UTF-8 byte length must not exceed
+ *       {@code gmail-buddy.send.max-body-size} (FR-013).</li>
+ *   <li>{@code bodyType} — optional, defaults to {@code "text"}, must be either
+ *       {@code "text"} or {@code "html"} when present (FR-014).</li>
+ * </ul>
+ *
+ * <h2>Compact constructor</h2>
+ * <p>Null collections are normalized to empty immutable lists so callers never
+ * receive a {@code null} collection reference from a deserialized payload.
+ * {@code bodyType} defaults to {@code "text"} when omitted.</p>
+ */
+public record SendMessageDTO(
+
+    @NotEmpty
+    @Size(min = 1, max = 500)
+    List<@NotBlank @OptionalEmail @NoHeaderInjection String> to,
+
+    @Size(max = 500)
+    List<@NotBlank @OptionalEmail @NoHeaderInjection String> cc,
+
+    @Size(max = 500)
+    List<@NotBlank @OptionalEmail @NoHeaderInjection String> bcc,
+
+    @NotBlank
+    @Size(max = 998)
+    @NoHeaderInjection
+    String subject,
+
+    @NotBlank
+    @MaxBodySize
+    String body,
+
+    @Pattern(regexp = "^(text|html)$")
+    String bodyType
+
+) {
+
+    /**
+     * Compact constructor that normalises null collections to empty immutable lists
+     * and defaults {@code bodyType} to {@code "text"} when absent.
+     *
+     * <p>Defensive {@link List#copyOf} calls ensure the internal state cannot be
+     * mutated through a reference the caller retained before passing the list in.</p>
+     */
+    public SendMessageDTO {
+        to = to == null ? List.of() : List.copyOf(to);
+        cc = cc == null ? List.of() : List.copyOf(cc);
+        bcc = bcc == null ? List.of() : List.copyOf(bcc);
+        bodyType = bodyType == null ? "text" : bodyType;
+    }
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/dto/response/DraftResponse.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/dto/response/DraftResponse.java
@@ -1,0 +1,36 @@
+package com.aucontraire.gmailbuddy.dto.response;
+
+/**
+ * Response DTO returned after a draft is staged successfully.
+ *
+ * <p>Returned by {@code POST /api/v1/gmail/drafts} (HTTP 201 Created).</p>
+ *
+ * <p>The {@code status} field is always {@code "DRAFT"} for this response type.
+ * Use the {@link #drafted(String, String, String)} factory method to construct
+ * instances so the sentinel value is set in one place and callers cannot
+ * accidentally pass an incorrect status string.</p>
+ *
+ * <p>The {@code draftId} is the identifier passed to
+ * {@code POST /api/v1/gmail/drafts/{draftId}/send} when the caller wants to
+ * trigger programmatic delivery of the staged draft.</p>
+ *
+ * @param draftId   the Gmail-assigned draft identifier
+ * @param messageId the Gmail-assigned underlying message identifier for the draft
+ * @param threadId  the Gmail conversation thread this draft belongs to
+ * @param status    always {@code "DRAFT"}
+ */
+public record DraftResponse(String draftId, String messageId, String threadId, String status) {
+
+    /**
+     * Factory method that creates a {@code DraftResponse} with {@code status}
+     * fixed to {@code "DRAFT"}.
+     *
+     * @param draftId   the Gmail-assigned draft identifier
+     * @param messageId the Gmail-assigned underlying message identifier
+     * @param threadId  the Gmail conversation thread identifier
+     * @return a new {@code DraftResponse} instance
+     */
+    public static DraftResponse drafted(String draftId, String messageId, String threadId) {
+        return new DraftResponse(draftId, messageId, threadId, "DRAFT");
+    }
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/dto/response/SendMessageResponse.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/dto/response/SendMessageResponse.java
@@ -1,0 +1,35 @@
+package com.aucontraire.gmailbuddy.dto.response;
+
+/**
+ * Response DTO returned after a message is delivered successfully.
+ *
+ * <p>Returned by both:</p>
+ * <ul>
+ *   <li>{@code POST /api/v1/gmail/messages} — direct send (HTTP 201 Created)</li>
+ *   <li>{@code POST /api/v1/gmail/drafts/{draftId}/send} — programmatic draft send
+ *       (HTTP 200 OK)</li>
+ * </ul>
+ *
+ * <p>The {@code status} field is always {@code "SENT"} for this response type.
+ * Use the {@link #sent(String, String)} factory method to construct instances so
+ * the sentinel value is set in one place and callers cannot accidentally pass an
+ * incorrect status string.</p>
+ *
+ * @param messageId the Gmail-assigned identifier for the delivered message
+ * @param threadId  the Gmail conversation thread this message belongs to
+ * @param status    always {@code "SENT"}
+ */
+public record SendMessageResponse(String messageId, String threadId, String status) {
+
+    /**
+     * Factory method that creates a {@code SendMessageResponse} with {@code status}
+     * fixed to {@code "SENT"}.
+     *
+     * @param messageId the Gmail-assigned message identifier
+     * @param threadId  the Gmail conversation thread identifier
+     * @return a new {@code SendMessageResponse} instance
+     */
+    public static SendMessageResponse sent(String messageId, String threadId) {
+        return new SendMessageResponse(messageId, threadId, "SENT");
+    }
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/exception/GlobalExceptionHandler.java
@@ -278,6 +278,11 @@ public class GlobalExceptionHandler {
     /**
      * Handles Spring validation exceptions for request body validation.
      * Maps to RFC 7807 ProblemDetail with field-level validation errors.
+     *
+     * <p>If any failing {@link FieldError} carries a {@code @NoHeaderInjection}
+     * constraint code, the response uses {@link ProblemTypes#HEADER_INJECTION_DETECTED}
+     * so security-relevant attempts can be triaged separately from ordinary input
+     * validation failures (FR-015, FR-018, SC-005).</p>
      */
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ProblemDetail> handleMethodArgumentNotValidException(MethodArgumentNotValidException ex) {
@@ -290,9 +295,32 @@ public class GlobalExceptionHandler {
             fieldErrors.put(fieldName, errorMessage);
         });
 
+        boolean headerInjectionDetected = ex.getBindingResult().getAllErrors().stream()
+                .filter(FieldError.class::isInstance)
+                .map(FieldError.class::cast)
+                .anyMatch(fe -> {
+                    String[] codes = fe.getCodes();
+                    if (codes == null) {
+                        return false;
+                    }
+                    for (String code : codes) {
+                        if (code != null && code.contains("NoHeaderInjection")) {
+                            return true;
+                        }
+                    }
+                    return false;
+                });
+
+        String problemType = headerInjectionDetected
+                ? ProblemTypes.HEADER_INJECTION_DETECTED
+                : ProblemTypes.VALIDATION_ERROR;
+        String title = headerInjectionDetected
+                ? "Header Injection Detected"
+                : "Validation Error";
+
         ProblemDetail.Builder builder = ProblemDetail.builder()
-                .type(ProblemTypes.VALIDATION_ERROR)
-                .title("Validation Error")
+                .type(problemType)
+                .title(title)
                 .status(HttpStatus.BAD_REQUEST.value())
                 .detail("Input validation failed for " + fieldErrors.size() + " field(s)")
                 .instance(request.getRequestURI())
@@ -305,7 +333,11 @@ public class GlobalExceptionHandler {
 
         ProblemDetail problem = builder.build();
 
-        logger.warn("Validation error: {} (correlation: {})", fieldErrors, requestId);
+        if (headerInjectionDetected) {
+            logger.warn("Header injection detected: {} (correlation: {})", fieldErrors, requestId);
+        } else {
+            logger.warn("Validation error: {} (correlation: {})", fieldErrors, requestId);
+        }
         return buildProblemResponse(problem, HttpStatus.BAD_REQUEST);
     }
 

--- a/src/main/java/com/aucontraire/gmailbuddy/exception/MessageSendException.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/exception/MessageSendException.java
@@ -1,0 +1,67 @@
+package com.aucontraire.gmailbuddy.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Exception thrown when the Gmail API rejects or fails to process a send or
+ * draft-send request in a way that cannot be attributed to the caller's input.
+ *
+ * <p>Maps to HTTP {@code 502 Bad Gateway} because the failure originates
+ * in the upstream Gmail API, not in the application itself nor in the
+ * caller's request.</p>
+ *
+ * <p>For daily-send-limit exceeded errors use
+ * {@link RateLimitException} with a {@code Retry-After} header of 86400 seconds.
+ * For resource-not-found scenarios (draft was discarded before send-draft call)
+ * use {@link ResourceNotFoundException}. This exception is the catch-all for
+ * other unexpected Gmail send failures ({@code /problems/message-send-failed}).</p>
+ *
+ * @see GmailBuddyServerException
+ */
+public class MessageSendException extends GmailBuddyServerException {
+
+    private static final String ERROR_CODE = "MESSAGE_SEND_FAILED";
+
+    /**
+     * Constructs a {@code MessageSendException} with the specified detail message.
+     *
+     * @param message a description of why the send failed (for logging; not
+     *                exposed verbatim in the API response)
+     */
+    public MessageSendException(String message) {
+        super(ERROR_CODE, message);
+    }
+
+    /**
+     * Constructs a {@code MessageSendException} with the specified detail message
+     * and the upstream cause.
+     *
+     * @param message a description of why the send failed
+     * @param cause   the upstream exception from the Gmail API client
+     */
+    public MessageSendException(String message, Throwable cause) {
+        super(ERROR_CODE, message, cause);
+    }
+
+    /**
+     * Constructs a {@code MessageSendException} with the specified detail message
+     * and a correlation ID for cross-request tracing.
+     *
+     * @param message       a description of why the send failed
+     * @param correlationId the correlation ID to associate with this failure
+     */
+    public MessageSendException(String message, String correlationId) {
+        super(ERROR_CODE, message, correlationId);
+    }
+
+    /**
+     * Returns {@code 502} (Bad Gateway) — the Gmail API is the upstream dependency
+     * that produced the failure.
+     *
+     * @return {@link HttpStatus#BAD_GATEWAY} value
+     */
+    @Override
+    public int getHttpStatus() {
+        return HttpStatus.BAD_GATEWAY.value();
+    }
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/mapper/GmailMessageMapper.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/mapper/GmailMessageMapper.java
@@ -1,0 +1,65 @@
+package com.aucontraire.gmailbuddy.mapper;
+
+import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
+import com.google.api.services.gmail.model.Draft;
+import com.google.api.services.gmail.model.Message;
+import org.springframework.stereotype.Component;
+
+/**
+ * Boundary mapper that converts Gmail SDK types into project-internal domain
+ * DTOs at the repository layer, keeping Gmail SDK types out of higher-level
+ * layer signatures.
+ *
+ * <p>Per Constitution Principle II and research.md Decision 13, repository
+ * interfaces MUST NOT expose Gmail API types. This mapper is the seam that
+ * converts {@link com.google.api.services.gmail.model.Message} and
+ * {@link com.google.api.services.gmail.model.Draft} to the corresponding
+ * project records before the data crosses the repository boundary.</p>
+ *
+ * <p>The service layer and controller layer are therefore free of Gmail SDK
+ * imports for the new send/draft code path.</p>
+ *
+ * @see SentMessageResult
+ * @see DraftCreationResult
+ */
+@Component
+public class GmailMessageMapper {
+
+    /**
+     * Converts a Gmail API {@link Message} (as returned by
+     * {@code users.messages.send} or {@code users.drafts.send}) into a
+     * {@link SentMessageResult} domain record.
+     *
+     * @param message the Gmail API message response; must not be {@code null}
+     * @return a {@link SentMessageResult} carrying the assigned message and
+     *         thread identifiers
+     * @throws NullPointerException if {@code message} is {@code null}
+     */
+    public SentMessageResult toSentMessageResult(Message message) {
+        return new SentMessageResult(message.getId(), message.getThreadId());
+    }
+
+    /**
+     * Converts a Gmail API {@link Draft} (as returned by
+     * {@code users.drafts.create}) into a {@link DraftCreationResult} domain
+     * record.
+     *
+     * <p>The {@code messageId} and {@code threadId} are extracted from the
+     * nested {@code draft.getMessage()} object that Gmail populates in the
+     * create response. If {@code draft.getMessage()} is {@code null} (should
+     * not occur for a successful create response), both identifiers are set to
+     * {@code null}.</p>
+     *
+     * @param draft the Gmail API draft response; must not be {@code null}
+     * @return a {@link DraftCreationResult} carrying the assigned draft, message,
+     *         and thread identifiers
+     * @throws NullPointerException if {@code draft} is {@code null}
+     */
+    public DraftCreationResult toDraftCreationResult(Draft draft) {
+        Message nestedMessage = draft.getMessage();
+        String messageId = nestedMessage != null ? nestedMessage.getId() : null;
+        String threadId  = nestedMessage != null ? nestedMessage.getThreadId() : null;
+        return new DraftCreationResult(draft.getId(), messageId, threadId);
+    }
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/ratelimit/GmailQuotaEstimator.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/ratelimit/GmailQuotaEstimator.java
@@ -30,6 +30,9 @@ public class GmailQuotaEstimator {
     private static final int MESSAGES_BATCH_MODIFY_QUOTA = 50;
     private static final int MESSAGES_DELETE_QUOTA = 10;
     private static final int MESSAGES_MODIFY_QUOTA = 5;
+    private static final int MESSAGES_SEND_QUOTA = 100;
+    private static final int DRAFTS_CREATE_QUOTA = 10;
+    private static final int DRAFTS_SEND_QUOTA = 100;
 
     /**
      * Estimates quota usage for listing messages.
@@ -134,5 +137,35 @@ public class GmailQuotaEstimator {
         // For now, we estimate this as just the search cost
         logger.debug("Estimated quota for filtering {} messages: {} units", messageCount, quota);
         return quota;
+    }
+
+    /**
+     * Estimates quota usage for sending a message directly (users.messages.send).
+     *
+     * @return Estimated quota units consumed
+     */
+    public int estimateSendMessageQuota() {
+        logger.debug("Estimated quota for sending message: {} units", MESSAGES_SEND_QUOTA);
+        return MESSAGES_SEND_QUOTA;
+    }
+
+    /**
+     * Estimates quota usage for creating a draft (users.drafts.create).
+     *
+     * @return Estimated quota units consumed
+     */
+    public int estimateCreateDraftQuota() {
+        logger.debug("Estimated quota for creating draft: {} units", DRAFTS_CREATE_QUOTA);
+        return DRAFTS_CREATE_QUOTA;
+    }
+
+    /**
+     * Estimates quota usage for sending an existing draft (users.drafts.send).
+     *
+     * @return Estimated quota units consumed
+     */
+    public int estimateSendDraftQuota() {
+        logger.debug("Estimated quota for sending draft: {} units", DRAFTS_SEND_QUOTA);
+        return DRAFTS_SEND_QUOTA;
     }
 }

--- a/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepository.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepository.java
@@ -1,8 +1,11 @@
 package com.aucontraire.gmailbuddy.repository;
 
 import com.aucontraire.gmailbuddy.service.BulkOperationResult;
+import com.aucontraire.gmailbuddy.service.DraftCreationResult;
 import com.aucontraire.gmailbuddy.service.MessageListResult;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
 import com.google.api.services.gmail.model.Message;
+import jakarta.mail.internet.MimeMessage;
 
 import java.io.IOException;
 import java.util.List;
@@ -24,4 +27,54 @@ public interface GmailRepository {
     String getMessageBody(String userId, String messageId) throws IOException;
     Map<String, String> getLabels(String userId) throws IOException;
     BulkOperationResult markMessageAsRead(String userId, String messageId) throws IOException;
+
+    /**
+     * Sends a fully-constructed MimeMessage immediately via the Gmail
+     * {@code users.messages.send} API call.
+     *
+     * @param userId      the Gmail user identifier; use {@code "me"} for the
+     *                    authenticated user
+     * @param mimeMessage the fully-populated RFC 5322 message to send
+     * @return assigned message and thread identifiers returned by Gmail
+     * @throws IOException          on network or Gmail API communication failure
+     * @throws com.aucontraire.gmailbuddy.exception.MessageSendException
+     *                              on Gmail send failure (mapped from
+     *                              {@code GoogleJsonResponseException} reasons)
+     */
+    SentMessageResult sendMessage(String userId, MimeMessage mimeMessage) throws IOException;
+
+    /**
+     * Stages a draft for later send or edit. The draft is immediately visible in
+     * the user's Gmail Drafts folder via {@code users.drafts.create}.
+     *
+     * @param userId      the Gmail user identifier; use {@code "me"} for the
+     *                    authenticated user
+     * @param mimeMessage the fully-populated RFC 5322 message to save as a draft
+     * @return assigned draft, message, and thread identifiers returned by Gmail
+     * @throws IOException          on network or Gmail API communication failure
+     * @throws com.aucontraire.gmailbuddy.exception.MessageSendException
+     *                              on Gmail draft-creation failure
+     */
+    DraftCreationResult createDraft(String userId, MimeMessage mimeMessage) throws IOException;
+
+    /**
+     * Sends a previously-created draft by identifier via the Gmail
+     * {@code users.drafts.send} API call.
+     *
+     * <p>Gmail removes the draft from the Drafts folder on a successful send,
+     * making this operation naturally idempotent at the resource level — a
+     * retry after a successful send returns {@code 404} from Gmail.</p>
+     *
+     * @param userId  the Gmail user identifier; use {@code "me"} for the
+     *                authenticated user
+     * @param draftId the Gmail draft identifier returned by {@link #createDraft}
+     * @return assigned message and thread identifiers of the sent message
+     * @throws IOException          on network or Gmail API communication failure
+     * @throws com.aucontraire.gmailbuddy.exception.ResourceNotFoundException
+     *                              if the draft does not exist (or was already
+     *                              sent or discarded)
+     * @throws com.aucontraire.gmailbuddy.exception.MessageSendException
+     *                              on other Gmail send failures
+     */
+    SentMessageResult sendDraft(String userId, String draftId) throws IOException;
 }

--- a/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java
@@ -387,18 +387,51 @@ public class GmailRepositoryImpl implements GmailRepository {
     }
 
     // -------------------------------------------------------------------------
-    // Send / Draft — T038 (createDraft) implemented; T045 (sendMessage) and
-    // T052 (sendDraft) remain as stubs pending their respective dispatches
+    // Send / Draft — T038 (createDraft), T045 (sendMessage), T052 (sendDraft)
+    // all fully implemented below
     // -------------------------------------------------------------------------
 
     /**
-     * Stub implementation. Full implementation arrives in T045.
+     * Sends an email message immediately via {@code users.messages.send}. The
+     * MimeMessage is serialized to its raw RFC 5322 byte form, base64url-encoded
+     * (RFC 4648 §5), and submitted to the Gmail API. The resulting {@link Message}
+     * is mapped to a {@link SentMessageResult} via {@link GmailMessageMapper}.
      *
-     * @throws UnsupportedOperationException always
+     * <p>Any {@link GoogleJsonResponseException} from the Gmail API is mapped to an
+     * appropriate project exception via {@link #mapGmailSendError(GoogleJsonResponseException)}.
+     * Other {@link IOException}s propagate per the interface declaration.</p>
+     *
+     * @param userId      the Gmail user identifier; typically {@code "me"}
+     * @param mimeMessage the fully-constructed RFC 5322 message to send
+     * @return a {@link SentMessageResult} containing the Gmail-assigned message
+     *         and thread identifiers
+     * @throws IOException if serialization, network I/O, or a non-JSON Gmail error occurs
      */
     @Override
     public SentMessageResult sendMessage(String userId, MimeMessage mimeMessage) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented — see T045");
+        try {
+            Gmail gmail = getGmailService();
+
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            mimeMessage.writeTo(buffer);
+            String encodedRaw = Base64.getUrlEncoder().encodeToString(buffer.toByteArray());
+
+            Message message = new Message().setRaw(encodedRaw);
+
+            Message sentMessage = gmail.users().messages().send(userId, message).execute();
+            logger.info("Message sent successfully for userId={}, messageId={}", userId, sentMessage.getId());
+
+            return gmailMessageMapper.toSentMessageResult(sentMessage);
+
+        } catch (GoogleJsonResponseException e) {
+            logger.error("Gmail API error sending message for userId={}: status={}, message={}",
+                    userId, e.getStatusCode(), e.getMessage());
+            throw mapGmailSendError(e);
+        } catch (GeneralSecurityException e) {
+            throw new IOException("Security exception creating Gmail service", e);
+        } catch (jakarta.mail.MessagingException e) {
+            throw new IOException("Failed to serialize MimeMessage for send", e);
+        }
     }
 
     /**
@@ -446,13 +479,46 @@ public class GmailRepositoryImpl implements GmailRepository {
     }
 
     /**
-     * Stub implementation. Full implementation arrives in T052.
+     * Sends a previously-created draft by identifier via {@code users.drafts.send}.
+     * A {@link Draft} with only the {@code id} field set is submitted; Gmail resolves
+     * the full message content from the draft store. The resulting {@link Message}
+     * is mapped to a {@link SentMessageResult} via {@link GmailMessageMapper}.
      *
-     * @throws UnsupportedOperationException always
+     * <p>This operation is naturally idempotent at the resource level: a successful
+     * send removes the draft. A subsequent retry returns a 404 from Gmail, which
+     * {@link #mapGmailSendError(GoogleJsonResponseException)} maps to
+     * {@link ResourceNotFoundException} (HTTP 404).</p>
+     *
+     * <p>Any {@link GoogleJsonResponseException} is mapped via
+     * {@link #mapGmailSendError(GoogleJsonResponseException)}. Other
+     * {@link IOException}s propagate per the interface declaration.</p>
+     *
+     * @param userId  the Gmail user identifier; typically {@code "me"}
+     * @param draftId the Gmail-assigned draft identifier
+     * @return a {@link SentMessageResult} containing the Gmail-assigned message
+     *         and thread identifiers
+     * @throws IOException if network I/O or a non-JSON Gmail error occurs
      */
     @Override
     public SentMessageResult sendDraft(String userId, String draftId) throws IOException {
-        throw new UnsupportedOperationException("Not yet implemented — see T052");
+        try {
+            Gmail gmail = getGmailService();
+
+            Draft draft = new Draft().setId(draftId);
+
+            Message sentMessage = gmail.users().drafts().send(userId, draft).execute();
+            logger.info("Draft sent successfully for userId={}, draftId={}, messageId={}",
+                    userId, draftId, sentMessage.getId());
+
+            return gmailMessageMapper.toSentMessageResult(sentMessage);
+
+        } catch (GoogleJsonResponseException e) {
+            logger.error("Gmail API error sending draft for userId={}, draftId={}: status={}, message={}",
+                    userId, draftId, e.getStatusCode(), e.getMessage());
+            throw mapGmailSendError(e);
+        } catch (GeneralSecurityException e) {
+            throw new IOException("Security exception creating Gmail service", e);
+        }
     }
 
     // -------------------------------------------------------------------------

--- a/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java
@@ -4,16 +4,27 @@ import com.aucontraire.gmailbuddy.client.GmailClient;
 import com.aucontraire.gmailbuddy.client.GmailBatchClient;
 import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
 import com.aucontraire.gmailbuddy.exception.AuthenticationException;
+import com.aucontraire.gmailbuddy.exception.AuthorizationException;
+import com.aucontraire.gmailbuddy.exception.MessageSendException;
+import com.aucontraire.gmailbuddy.exception.RateLimitException;
+import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
+import com.aucontraire.gmailbuddy.exception.ValidationException;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
+import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
 import com.aucontraire.gmailbuddy.service.TokenProvider;
 import com.aucontraire.gmailbuddy.service.BulkOperationResult;
 import com.aucontraire.gmailbuddy.service.MessageListResult;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.gmail.Gmail;
 import com.google.api.services.gmail.model.*;
+import jakarta.mail.internet.MimeMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.*;
@@ -25,15 +36,18 @@ public class GmailRepositoryImpl implements GmailRepository {
     private final GmailBatchClient gmailBatchClient;
     private final TokenProvider tokenProvider;
     private final GmailBuddyProperties properties;
+    private final GmailMessageMapper gmailMessageMapper;
     private final Logger logger = LoggerFactory.getLogger(GmailRepositoryImpl.class);
 
     @Autowired
     public GmailRepositoryImpl(GmailClient gmailClient, GmailBatchClient gmailBatchClient,
-                              TokenProvider tokenProvider, GmailBuddyProperties properties) {
+                              TokenProvider tokenProvider, GmailBuddyProperties properties,
+                              GmailMessageMapper gmailMessageMapper) {
         this.gmailClient = gmailClient;
         this.gmailBatchClient = gmailBatchClient;
         this.tokenProvider = tokenProvider;
         this.properties = properties;
+        this.gmailMessageMapper = gmailMessageMapper;
     }
 
     private Gmail getGmailService() throws IOException, GeneralSecurityException {
@@ -370,5 +384,160 @@ public class GmailRepositoryImpl implements GmailRepository {
         } catch (GeneralSecurityException e) {
             throw new IOException("Security exception creating Gmail service", e);
         }
+    }
+
+    // -------------------------------------------------------------------------
+    // Send / Draft — T038 (createDraft) implemented; T045 (sendMessage) and
+    // T052 (sendDraft) remain as stubs pending their respective dispatches
+    // -------------------------------------------------------------------------
+
+    /**
+     * Stub implementation. Full implementation arrives in T045.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public SentMessageResult sendMessage(String userId, MimeMessage mimeMessage) throws IOException {
+        throw new UnsupportedOperationException("Not yet implemented — see T045");
+    }
+
+    /**
+     * Stages a draft for later send/edit. The MimeMessage is serialized to its raw
+     * RFC 5322 byte form, base64url-encoded (RFC 4648 §5), and submitted to the
+     * Gmail API via {@code users.drafts.create}. The resulting {@link Draft} is
+     * mapped to a {@link DraftCreationResult} via {@link GmailMessageMapper}.
+     *
+     * <p>Any {@link GoogleJsonResponseException} from the Gmail API is mapped to an
+     * appropriate project exception via {@link #mapGmailSendError(GoogleJsonResponseException)}.
+     * Other {@link IOException}s propagate per the interface declaration.</p>
+     *
+     * @param userId      the Gmail user identifier; typically {@code "me"}
+     * @param mimeMessage the fully-constructed RFC 5322 message to stage as a draft
+     * @return a {@link DraftCreationResult} containing the Gmail-assigned draft,
+     *         message, and thread identifiers
+     * @throws IOException if serialization, network I/O, or a non-JSON Gmail error occurs
+     */
+    @Override
+    public DraftCreationResult createDraft(String userId, MimeMessage mimeMessage) throws IOException {
+        try {
+            Gmail gmail = getGmailService();
+
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            mimeMessage.writeTo(buffer);
+            String encodedRaw = Base64.getUrlEncoder().encodeToString(buffer.toByteArray());
+
+            Message rawMessage = new Message().setRaw(encodedRaw);
+            Draft draft = new Draft().setMessage(rawMessage);
+
+            Draft createdDraft = gmail.users().drafts().create(userId, draft).execute();
+            logger.info("Draft created successfully for userId={}, draftId={}", userId, createdDraft.getId());
+
+            return gmailMessageMapper.toDraftCreationResult(createdDraft);
+
+        } catch (GoogleJsonResponseException e) {
+            logger.error("Gmail API error creating draft for userId={}: status={}, message={}",
+                    userId, e.getStatusCode(), e.getMessage());
+            throw mapGmailSendError(e);
+        } catch (GeneralSecurityException e) {
+            throw new IOException("Security exception creating Gmail service", e);
+        } catch (jakarta.mail.MessagingException e) {
+            throw new IOException("Failed to serialize MimeMessage for draft creation", e);
+        }
+    }
+
+    /**
+     * Stub implementation. Full implementation arrives in T052.
+     *
+     * @throws UnsupportedOperationException always
+     */
+    @Override
+    public SentMessageResult sendDraft(String userId, String draftId) throws IOException {
+        throw new UnsupportedOperationException("Not yet implemented — see T052");
+    }
+
+    // -------------------------------------------------------------------------
+    // Private error-mapping helper (research.md Decision 10)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Maps a {@link GoogleJsonResponseException} from a Gmail send or draft-send
+     * call to the appropriate project exception.
+     *
+     * <p>Error reasons are extracted from
+     * {@code e.getDetails().getErrors().get(0).getReason()} when available.
+     * The mapping follows research.md Decision 10:</p>
+     *
+     * <ul>
+     *   <li>{@code invalidArgument} → {@link ValidationException} (HTTP 422)</li>
+     *   <li>{@code insufficientPermissions} → {@link AuthorizationException} (HTTP 403)</li>
+     *   <li>{@code dailySendLimitExceeded} → {@link RateLimitException}
+     *       with {@code retryAfterSeconds=86400} (HTTP 429).
+     *       <strong>CRITICAL: this path MUST NOT route through any retry-with-backoff
+     *       logic.</strong> The limit resets at the next calendar day; exponential
+     *       backoff is useless and wastes quota.</li>
+     *   <li>{@code forbidden} (unverified send-as identity) → {@link AuthorizationException}
+     *       (HTTP 403)</li>
+     *   <li>{@code messageTooLarge} → {@link ValidationException} (HTTP 413 via
+     *       {@code GlobalExceptionHandler}; may become a dedicated exception in v2)</li>
+     *   <li>HTTP 404 (draft does not exist — drafts.send only) →
+     *       {@link ResourceNotFoundException} (HTTP 404)</li>
+     *   <li>Any other 4xx / 5xx → {@link MessageSendException} (HTTP 502)</li>
+     * </ul>
+     *
+     * @param e the exception thrown by the Gmail API client
+     * @return a project exception whose type matches the Gmail error reason
+     */
+    private RuntimeException mapGmailSendError(GoogleJsonResponseException e) {
+        int statusCode = e.getStatusCode();
+
+        // 404 always maps to ResourceNotFoundException (draft not found / already sent)
+        if (statusCode == 404) {
+            return new ResourceNotFoundException(
+                    "Draft not found or already sent/discarded", e);
+        }
+
+        // Extract the error reason from the first error detail when present
+        String reason = null;
+        if (e.getDetails() != null
+                && e.getDetails().getErrors() != null
+                && !e.getDetails().getErrors().isEmpty()) {
+            reason = e.getDetails().getErrors().get(0).getReason();
+        }
+
+        if (reason == null) {
+            return new MessageSendException("Gmail send failed: HTTP " + statusCode, e);
+        }
+
+        return switch (reason) {
+            case "invalidArgument" ->
+                    new ValidationException(
+                            "Gmail rejected one or more recipient addresses or message fields", e);
+
+            case "insufficientPermissions" ->
+                    new AuthorizationException(
+                            "Insufficient Gmail permissions to send mail", e);
+
+            // CRITICAL: dailySendLimitExceeded MUST NOT go through any retry-with-backoff
+            // path. The daily send limit resets at the next calendar day; retrying within
+            // the same day wastes quota and does not resolve the limit. retryAfterSeconds
+            // is set to 86400 (24 hours) to inform the caller of the reset window.
+            case "dailySendLimitExceeded" ->
+                    new RateLimitException(
+                            "Daily Gmail send limit reached; retry after the next-day reset",
+                            e,
+                            86400L);
+
+            case "forbidden" ->
+                    new AuthorizationException(
+                            "Gmail rejected send: forbidden (unverified send-as identity or account restricted)", e);
+
+            case "messageTooLarge" ->
+                    new ValidationException(
+                            "Message exceeds Gmail's maximum allowed size", e);
+
+            default ->
+                    new MessageSendException(
+                            "Gmail send failed with reason: " + reason, e);
+        };
     }
 }

--- a/src/main/java/com/aucontraire/gmailbuddy/security/TokenReferenceService.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/security/TokenReferenceService.java
@@ -70,6 +70,25 @@ public class TokenReferenceService {
     }
 
     /**
+     * Creates a secure token reference with the actual OAuth2 scope from the validated token.
+     *
+     * Use this overload when the caller has already validated the token and has the scope string
+     * available (e.g., from {@code GoogleTokenValidator.TokenInfoResponse#getScope()}). Storing
+     * the real scope in the token reference metadata ensures audit logs and reference lookups
+     * reflect what the token actually authorizes, rather than a hardcoded placeholder.
+     *
+     * @param rawToken the raw OAuth2 access token
+     * @param userId the user identifier (email or user ID)
+     * @param scope the OAuth2 scope string from the validated token (e.g., from tokenInfo.getScope())
+     * @return TokenReference containing encrypted token and metadata
+     * @throws IllegalArgumentException if parameters are invalid
+     * @throws RuntimeException if encryption fails
+     */
+    public TokenReference createTokenReference(String rawToken, String userId, String scope) {
+        return createTokenReference(rawToken, userId, scope, defaultTokenLifetimeSeconds);
+    }
+
+    /**
      * Creates a secure token reference with custom lifetime.
      *
      * @param rawToken the raw OAuth2 access token
@@ -80,6 +99,25 @@ public class TokenReferenceService {
      * @throws RuntimeException if encryption fails
      */
     public TokenReference createTokenReference(String rawToken, String userId, long lifetimeSeconds) {
+        return createTokenReference(rawToken, userId, null, lifetimeSeconds);
+    }
+
+    /**
+     * Creates a secure token reference with explicit scope and custom lifetime.
+     *
+     * This is the canonical implementation. All other overloads delegate here.
+     * When {@code scope} is null or blank, the field is stored as-is (null) rather than
+     * substituting a hardcoded default — callers that care about scope should supply it.
+     *
+     * @param rawToken the raw OAuth2 access token
+     * @param userId the user identifier (email or user ID)
+     * @param scope the OAuth2 scope string, or null if not available to the caller
+     * @param lifetimeSeconds token lifetime in seconds
+     * @return TokenReference containing encrypted token and metadata
+     * @throws IllegalArgumentException if parameters are invalid
+     * @throws RuntimeException if encryption fails
+     */
+    private TokenReference createTokenReference(String rawToken, String userId, String scope, long lifetimeSeconds) {
         if (rawToken == null || rawToken.trim().isEmpty()) {
             throw new IllegalArgumentException("Raw token cannot be null or empty");
         }
@@ -94,12 +132,12 @@ public class TokenReferenceService {
             // Encrypt the raw token
             String encryptedToken = encryptionUtil.encrypt(rawToken);
 
-            // Create token reference
+            // Create token reference with the actual scope from the validated token
             TokenReference tokenReference = TokenReference.builder()
                     .encryptedToken(encryptedToken)
                     .userId(userId)
                     .expiresIn(lifetimeSeconds)
-                    .scope("gmail.readonly gmail.modify") // Default Gmail scopes
+                    .scope(scope)
                     .build();
 
             // Store in cache

--- a/src/main/java/com/aucontraire/gmailbuddy/service/DraftCreationResult.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/service/DraftCreationResult.java
@@ -1,0 +1,4 @@
+package com.aucontraire.gmailbuddy.service;
+
+/** Immutable domain DTO returned by the repository after a draft is created, carrying the Gmail-assigned draft, message, and thread identifiers. */
+public record DraftCreationResult(String draftId, String messageId, String threadId) {}

--- a/src/main/java/com/aucontraire/gmailbuddy/service/GmailService.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/service/GmailService.java
@@ -2,6 +2,7 @@ package com.aucontraire.gmailbuddy.service;
 
 import com.aucontraire.gmailbuddy.dto.DeleteResult;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaWithLabelsDTO;
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
 import com.aucontraire.gmailbuddy.exception.GmailApiException;
 import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
 import com.aucontraire.gmailbuddy.mapper.FilterCriteriaMapper;
@@ -9,12 +10,15 @@ import com.aucontraire.gmailbuddy.repository.GmailRepository;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaDTO;
 import com.google.api.services.gmail.model.FilterCriteria;
 import com.google.api.services.gmail.model.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 @Service
@@ -23,13 +27,16 @@ public class GmailService {
     private final GmailRepository gmailRepository;
     private final GmailQueryBuilder gmailQueryBuilder;
     private final FilterCriteriaMapper filterCriteriaMapper;
+    private final MimeMessageBuilder mimeMessageBuilder;
     private final Logger logger = LoggerFactory.getLogger(GmailService.class);
 
     @Autowired
-    public GmailService(GmailRepository gmailRepository, GmailQueryBuilder gmailQueryBuilder, FilterCriteriaMapper filterCriteriaMapper) {
+    public GmailService(GmailRepository gmailRepository, GmailQueryBuilder gmailQueryBuilder,
+                        FilterCriteriaMapper filterCriteriaMapper, MimeMessageBuilder mimeMessageBuilder) {
         this.gmailRepository = gmailRepository;
         this.gmailQueryBuilder = gmailQueryBuilder;
         this.filterCriteriaMapper = filterCriteriaMapper;
+        this.mimeMessageBuilder = mimeMessageBuilder;
     }
 
     public String buildQuery(FilterCriteria filterCriteria) {
@@ -261,6 +268,37 @@ public class GmailService {
             throw new GmailApiException(
                     String.format("Failed to mark message as read for messageId: %s for user: %s", messageId, userId),
                     e
+            );
+        }
+    }
+
+    /**
+     * Stages a draft email in the user's Gmail Drafts folder. The DTO is first
+     * converted to a {@link MimeMessage} via {@link MimeMessageBuilder}, then
+     * submitted to the Gmail API via the repository layer.
+     *
+     * <p>This is the default outreach path for AI-personalized content — the draft
+     * is immediately visible in any Gmail client for the user to review, edit,
+     * send, or discard before delivery.</p>
+     *
+     * @param userId the Gmail user identifier; typically {@code "me"}
+     * @param dto    the validated send request containing recipients, subject, and body
+     * @return a {@link DraftCreationResult} with the Gmail-assigned draft, message,
+     *         and thread identifiers
+     * @throws GmailApiException if MimeMessage construction fails or the Gmail API
+     *                           returns an error
+     */
+    public DraftCreationResult createDraft(String userId, SendMessageDTO dto) throws GmailApiException {
+        try {
+            MimeMessage mimeMessage = mimeMessageBuilder.build(dto);
+            return gmailRepository.createDraft(userId, mimeMessage);
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            logger.error("Failed to build MimeMessage for draft creation for user: {}", userId, e);
+            throw new GmailApiException("Failed to construct email message for draft", e);
+        } catch (IOException e) {
+            logger.error("Failed to create draft for user: {}", userId, e);
+            throw new GmailApiException(
+                    String.format("Failed to create draft for user: %s", userId), e
             );
         }
     }

--- a/src/main/java/com/aucontraire/gmailbuddy/service/GmailService.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/service/GmailService.java
@@ -302,4 +302,59 @@ public class GmailService {
             );
         }
     }
+
+    /**
+     * Sends a previously-created draft by its identifier. Thin pass-through to the
+     * repository layer — no MimeMessage construction is needed because the message
+     * content already lives in Gmail's draft store.
+     *
+     * <p>Naturally idempotent at the resource level: if the draft was already sent
+     * (or discarded), Gmail returns 404 and the repository maps it to
+     * {@link com.aucontraire.gmailbuddy.exception.ResourceNotFoundException}, which
+     * the controller returns as HTTP 404.</p>
+     *
+     * @param userId  the Gmail user identifier; typically {@code "me"}
+     * @param draftId the Gmail-assigned draft identifier returned by {@link #createDraft}
+     * @return a {@link SentMessageResult} with the Gmail-assigned message and thread identifiers
+     * @throws GmailApiException if the Gmail API returns an error
+     */
+    public SentMessageResult sendDraft(String userId, String draftId) throws GmailApiException {
+        try {
+            return gmailRepository.sendDraft(userId, draftId);
+        } catch (IOException e) {
+            logger.error("Failed to send draft for draftId: {} for user: {}", draftId, userId, e);
+            throw new GmailApiException(
+                    String.format("Failed to send draft for draftId: %s for user: %s", draftId, userId), e
+            );
+        }
+    }
+
+    /**
+     * Sends an email message immediately. The DTO is first converted to a
+     * {@link MimeMessage} via {@link MimeMessageBuilder}, then submitted to the
+     * Gmail API via the repository layer.
+     *
+     * <p>Reserved for deterministic, pre-trusted templates. Callers MUST NOT
+     * auto-retry POSTs after a network timeout — duplicate sends may result.</p>
+     *
+     * @param userId the Gmail user identifier; typically {@code "me"}
+     * @param dto    the validated send request containing recipients, subject, and body
+     * @return a {@link SentMessageResult} with the Gmail-assigned message and thread identifiers
+     * @throws GmailApiException if MimeMessage construction fails or the Gmail API
+     *                           returns an error
+     */
+    public SentMessageResult sendMessage(String userId, SendMessageDTO dto) throws GmailApiException {
+        try {
+            MimeMessage mimeMessage = mimeMessageBuilder.build(dto);
+            return gmailRepository.sendMessage(userId, mimeMessage);
+        } catch (MessagingException | UnsupportedEncodingException e) {
+            logger.error("Failed to build MimeMessage for send for user: {}", userId, e);
+            throw new GmailApiException("Failed to construct email message for send", e);
+        } catch (IOException e) {
+            logger.error("Failed to send message for user: {}", userId, e);
+            throw new GmailApiException(
+                    String.format("Failed to send message for user: %s", userId), e
+            );
+        }
+    }
 }

--- a/src/main/java/com/aucontraire/gmailbuddy/service/GoogleTokenValidator.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/service/GoogleTokenValidator.java
@@ -35,10 +35,23 @@ public class GoogleTokenValidator {
     /**
      * Required Gmail scopes for API access.
      * At least one of these scopes must be present in the validated token.
+     *
+     * Scope rationale:
+     * - gmail.readonly / gmail.modify: cover standard read and label-mutation operations.
+     * - gmail.send: required so that least-privilege Bearer tokens issued to the Python consumer
+     *   (which carry only gmail.send) pass this filter and reach the send/draft endpoints.
+     *   Without this entry a send-only token is rejected with HTTP 401 before hitting the controller.
+     * - mail.google.com: load-bearing for the existing DELETE endpoints. Both DELETE paths route
+     *   through GmailBatchClient.executeNativeBatchDelete() which calls users().messages().batchDelete()
+     *   — a permanent, irreversible delete operation. gmail.modify only authorises trash(); batchDelete
+     *   requires the full-access mail.google.com scope. Removing this entry would break both DELETE
+     *   endpoints with HTTP 403 insufficientPermissions.
      */
     private static final Set<String> REQUIRED_GMAIL_SCOPES = Set.of(
         "https://www.googleapis.com/auth/gmail.readonly",
         "https://www.googleapis.com/auth/gmail.modify",
+        // Allows least-privilege send-only Bearer tokens from the Python consumer to pass validation.
+        "https://www.googleapis.com/auth/gmail.send",
         // Required for users.messages.batchDelete (permanent delete used by DELETE endpoints).
         // gmail.modify only permits trash(); batchDelete requires the full-access scope.
         "https://mail.google.com/"

--- a/src/main/java/com/aucontraire/gmailbuddy/service/MimeMessageBuilder.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/service/MimeMessageBuilder.java
@@ -1,0 +1,116 @@
+package com.aucontraire.gmailbuddy.service;
+
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+import jakarta.mail.Message.RecipientType;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import org.springframework.stereotype.Component;
+
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Properties;
+
+/**
+ * Converts a {@link SendMessageDTO} into a fully-constructed
+ * {@link MimeMessage} ready for base64url encoding and submission to the Gmail
+ * API via {@code users.messages.send} or {@code users.drafts.create}.
+ *
+ * <p>This builder is a pure conversion utility. It performs no validation
+ * beyond what JavaMail itself enforces during address parsing (validation is the
+ * responsibility of the Bean Validation layer on {@code SendMessageDTO}).</p>
+ *
+ * <p>HTML bodies are forwarded verbatim without server-side sanitization per
+ * research.md Decision 7. The recipient's email client is the trust boundary
+ * for render safety.</p>
+ *
+ * <h2>Content-type mapping</h2>
+ * <ul>
+ *   <li>{@code bodyType = "text"} → MIME type {@code text/plain; charset=UTF-8}</li>
+ *   <li>{@code bodyType = "html"} → MIME type {@code text/html; charset=UTF-8}</li>
+ * </ul>
+ *
+ * <h2>Recipient handling</h2>
+ * <p>Each address in {@code to}, {@code cc}, and {@code bcc} is parsed via
+ * {@link InternetAddress#parse(String)} and set on the appropriate
+ * {@link RecipientType}. Empty or null lists produce no recipient headers for
+ * that field.</p>
+ *
+ * @see SendMessageDTO
+ * @see MimeMessage
+ */
+@Component
+public class MimeMessageBuilder {
+
+    private static final String CONTENT_TYPE_TEXT_PLAIN = "text/plain; charset=UTF-8";
+    private static final String CONTENT_TYPE_TEXT_HTML  = "text/html; charset=UTF-8";
+
+    /**
+     * Builds a {@link MimeMessage} from the validated {@link SendMessageDTO}.
+     *
+     * <p>The returned {@code MimeMessage} is created on a minimal no-op JavaMail
+     * {@link Session} (no SMTP configuration) because delivery goes through the
+     * Gmail HTTP API, not SMTP.</p>
+     *
+     * @param dto the validated send request DTO; must not be {@code null}
+     * @return a fully-populated {@code MimeMessage}
+     * @throws MessagingException            if JavaMail encounters an error while
+     *                                       constructing or setting headers/content
+     * @throws UnsupportedEncodingException  if the UTF-8 charset is unavailable
+     *                                       (should never occur on any conforming JVM)
+     */
+    public MimeMessage build(SendMessageDTO dto)
+            throws MessagingException, UnsupportedEncodingException {
+
+        Session session = Session.getDefaultInstance(new Properties());
+        MimeMessage message = new MimeMessage(session);
+
+        setRecipients(message, RecipientType.TO, dto.to());
+        setRecipients(message, RecipientType.CC, dto.cc());
+        setRecipients(message, RecipientType.BCC, dto.bcc());
+
+        message.setSubject(dto.subject(), StandardCharsets.UTF_8.name());
+
+        String contentType = "html".equalsIgnoreCase(dto.bodyType())
+                ? CONTENT_TYPE_TEXT_HTML
+                : CONTENT_TYPE_TEXT_PLAIN;
+        message.setContent(dto.body(), contentType);
+
+        // Materialize all staged changes into the actual MIME header set so that
+        // getContentType(), getRecipients(), and writeTo() all reflect the intended
+        // values without requiring the caller to invoke saveChanges() themselves.
+        message.saveChanges();
+
+        return message;
+    }
+
+    /**
+     * Parses the address strings in {@code addresses} and sets them on
+     * {@code message} for the given {@code recipientType}. Does nothing when
+     * the list is {@code null} or empty.
+     *
+     * @param message       the message to modify
+     * @param recipientType {@code TO}, {@code CC}, or {@code BCC}
+     * @param addresses     the list of RFC 5322 address strings
+     * @throws MessagingException if any address cannot be set
+     */
+    private void setRecipients(MimeMessage message,
+                                RecipientType recipientType,
+                                List<String> addresses)
+            throws MessagingException {
+
+        if (addresses == null || addresses.isEmpty()) {
+            return;
+        }
+
+        InternetAddress[] parsed = new InternetAddress[addresses.size()];
+        for (int i = 0; i < addresses.size(); i++) {
+            // InternetAddress.parse is lenient; validation already done by DTO constraints.
+            InternetAddress[] singleParsed = InternetAddress.parse(addresses.get(i), false);
+            parsed[i] = singleParsed[0];
+        }
+        message.setRecipients(recipientType, parsed);
+    }
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/service/SentMessageResult.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/service/SentMessageResult.java
@@ -1,0 +1,4 @@
+package com.aucontraire.gmailbuddy.service;
+
+/** Immutable domain DTO returned by the repository after a message is sent, carrying the Gmail-assigned message and thread identifiers. */
+public record SentMessageResult(String messageId, String threadId) {}

--- a/src/main/java/com/aucontraire/gmailbuddy/util/CrlfSanitizingMessageConverter.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/util/CrlfSanitizingMessageConverter.java
@@ -1,0 +1,49 @@
+package com.aucontraire.gmailbuddy.util;
+
+import ch.qos.logback.classic.pattern.MessageConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+
+/**
+ * Logback MessageConverter that escapes CR and LF characters in every formatted
+ * log message before it is written to any appender.
+ *
+ * <p>Purpose (FR-024): Any user-supplied string that reaches log output — including
+ * recipient email addresses, subject lines, rejected-value fields from validation
+ * failures, and Gmail query strings derived from request fields — may contain
+ * carriage-return ({@code \r}, U+000D) or line-feed ({@code \n}, U+000A) characters.
+ * Leaving these characters unsanitized allows an attacker to inject synthetic log
+ * lines by crafting a value such as {@code victim@example.com\nINFO 2026-01-01 FAKE
+ * LOG LINE}. The converter replaces {@code \r} with the literal four-character
+ * sequence {@code \\r} and {@code \n} with {@code \\n}, making injected newlines
+ * visible as data rather than as log-line boundaries.
+ *
+ * <p>Registration: This converter is registered in {@code logback.xml} via the
+ * {@code <conversionRule>} element using the conversion word {@code sanitizedMsg},
+ * which replaces the standard {@code %msg} specifier in the encoder pattern.
+ * Because sanitization is applied inside the pattern rather than at individual
+ * log-call sites, it cannot be bypassed by a {@code log.info(...)} call that
+ * omits a manual sanitization step.
+ *
+ * <p>Constitution-VII deviation context: Recipient email addresses and subject
+ * lines are PII under a strict reading of Constitution Principle VII. They are
+ * logged under a controlled deviation justified in plan.md § Complexity Tracking
+ * (single-user, local-machine deployment; operator is the data controller).
+ * This converter mitigates one specific risk of that deviation — log-line injection
+ * — but does not lift the underlying PII-in-logs concern. Revisit if external log
+ * shipping or multi-user mode is introduced.
+ *
+ * @see <a href="../../../../../../../specs/001-send-draft-emails/spec.md">FR-024</a>
+ */
+public class CrlfSanitizingMessageConverter extends MessageConverter {
+
+    @Override
+    public String convert(ILoggingEvent event) {
+        String message = super.convert(event);
+        if (message == null) {
+            return null;
+        }
+        return message
+                .replace("\r", "\\r")
+                .replace("\n", "\\n");
+    }
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/validation/MaxBodySize.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/validation/MaxBodySize.java
@@ -1,0 +1,53 @@
+package com.aucontraire.gmailbuddy.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+/**
+ * Constraint annotation that enforces a maximum message-body size measured in
+ * UTF-8 bytes.
+ *
+ * <p>The limit is read from {@code gmail-buddy.send.max-body-size} via
+ * {@link com.aucontraire.gmailbuddy.config.GmailBuddyProperties.Send#maxBodySize()}.
+ * By default that property is set to {@code 10MB} in {@code application.properties},
+ * aligning with Spring Boot's {@code spring.servlet.multipart.max-request-size}
+ * and Gmail's practical per-message body ceiling for outreach use-cases.</p>
+ *
+ * <p>UTF-8 byte length — rather than Java character count — is used because Gmail
+ * API accepts the raw-message byte stream. A body that fits within the character
+ * limit can still exceed the byte limit when it contains multibyte Unicode
+ * characters.</p>
+ *
+ * <p>Null values are treated as valid — presence enforcement is the responsibility
+ * of {@link jakarta.validation.constraints.NotBlank}, not this constraint.</p>
+ *
+ * @see MaxBodySizeValidator
+ */
+@Documented
+@Constraint(validatedBy = MaxBodySizeValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MaxBodySize {
+
+    /**
+     * Violation message returned when the body exceeds the configured byte limit.
+     *
+     * @return the error message template
+     */
+    String message() default "Message body exceeds the maximum permitted size";
+
+    /**
+     * Validation groups this constraint belongs to.
+     *
+     * @return the groups
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * Payload for extensibility by constraint consumers.
+     *
+     * @return the payload
+     */
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/validation/MaxBodySizeValidator.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/validation/MaxBodySizeValidator.java
@@ -1,0 +1,77 @@
+package com.aucontraire.gmailbuddy.validation;
+
+import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Validator for the {@link MaxBodySize} constraint.
+ *
+ * <p>Measures the UTF-8 byte length of the supplied string and rejects it when that
+ * length exceeds the limit configured in
+ * {@link GmailBuddyProperties.Send#maxBodySize()}
+ * ({@code gmail-buddy.send.max-body-size} in {@code application.properties},
+ * defaulting to {@code 10MB}).</p>
+ *
+ * <p>Returns {@code true} for {@code null} values — presence enforcement is
+ * delegated to {@link jakarta.validation.constraints.NotBlank}.</p>
+ *
+ * <h2>Injection strategy</h2>
+ * <p>Spring Boot integrates Bean Validation with the Spring application context so
+ * that {@code ConstraintValidator} implementations can be Spring beans. This class
+ * receives {@link GmailBuddyProperties} via {@link Autowired} field injection —
+ * the recommended approach documented in
+ * <a href="https://docs.spring.io/spring-framework/reference/core/validation/beanvalidation.html#bean-validation-spring-constraints">
+ * Spring Framework reference: Spring-driven Method Validation</a> — because
+ * {@code ConstraintValidator} lifecycle is managed by Hibernate Validator, which
+ * asks Spring's {@code SpringConstraintValidatorFactory} to fulfill dependencies
+ * after instantiation. Constructor injection is not available at that point, so
+ * field-level {@code @Autowired} is the idiomatic pattern for Spring-managed
+ * validators.</p>
+ *
+ * @see MaxBodySize
+ */
+public class MaxBodySizeValidator implements ConstraintValidator<MaxBodySize, String> {
+
+    /**
+     * Application configuration properties. Injected by Spring's
+     * {@code SpringConstraintValidatorFactory} after Hibernate Validator
+     * instantiates this class.
+     */
+    @Autowired
+    private GmailBuddyProperties gmailBuddyProperties;
+
+    /**
+     * Initializes the validator. Configuration is read from the injected
+     * {@link GmailBuddyProperties} at validation time rather than here, so
+     * property changes that take effect without restart are reflected immediately.
+     *
+     * @param constraintAnnotation the annotation instance (unused)
+     */
+    @Override
+    public void initialize(MaxBodySize constraintAnnotation) {
+        // No annotation-level configuration; limit is sourced from GmailBuddyProperties.
+    }
+
+    /**
+     * Returns {@code true} if {@code value} is {@code null} or its UTF-8 byte
+     * length does not exceed {@code gmail-buddy.send.max-body-size}; {@code false}
+     * otherwise.
+     *
+     * @param value   the message body to measure (may be {@code null})
+     * @param context the constraint validator context
+     * @return {@code true} when the body is within the configured size limit
+     */
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        long maxBytes = gmailBuddyProperties.send().maxBodySize().toBytes();
+        long actualBytes = value.getBytes(StandardCharsets.UTF_8).length;
+        return actualBytes <= maxBytes;
+    }
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjection.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjection.java
@@ -35,7 +35,7 @@ public @interface NoHeaderInjection {
      *
      * @return the error message template
      */
-    String message() default "Header-injection characters (\\r or \\n) are not permitted";
+    String message() default "Header-injection characters (line-terminator characters) are not permitted";
 
     /**
      * Validation groups this constraint belongs to.

--- a/src/main/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjection.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjection.java
@@ -1,0 +1,53 @@
+package com.aucontraire.gmailbuddy.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import java.lang.annotation.*;
+
+/**
+ * Constraint annotation that rejects strings containing carriage-return ({@code \r})
+ * or line-feed ({@code \n}) characters.
+ *
+ * <p>Apply this annotation to every string field whose value will land in an email
+ * header (recipient addresses, subject line, and any future alias or reply-to fields).
+ * Header injection via embedded CRLF sequences is a well-known attack vector for
+ * crafting malicious headers and must be blocked before message construction begins.</p>
+ *
+ * <p>Null values are treated as valid — presence enforcement is the responsibility
+ * of {@link jakarta.validation.constraints.NotBlank} or
+ * {@link jakarta.validation.constraints.NotNull}, not this constraint. This separation
+ * honours the Single Responsibility Principle and avoids duplicating presence semantics.</p>
+ *
+ * <p>The {@code TYPE_USE} target enables per-element annotation on generic type
+ * arguments, allowing usage such as
+ * {@code List<@NoHeaderInjection String>}.</p>
+ *
+ * @see NoHeaderInjectionValidator
+ */
+@Documented
+@Constraint(validatedBy = NoHeaderInjectionValidator.class)
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface NoHeaderInjection {
+
+    /**
+     * Violation message returned when the constraint is not satisfied.
+     *
+     * @return the error message template
+     */
+    String message() default "Header-injection characters (\\r or \\n) are not permitted";
+
+    /**
+     * Validation groups this constraint belongs to.
+     *
+     * @return the groups
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * Payload for extensibility by constraint consumers.
+     *
+     * @return the payload
+     */
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjectionValidator.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjectionValidator.java
@@ -1,0 +1,52 @@
+package com.aucontraire.gmailbuddy.validation;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+/**
+ * Validator for the {@link NoHeaderInjection} constraint.
+ *
+ * <p>Returns {@code false} when the supplied string contains a carriage-return
+ * ({@code '\r'}, U+000D) or a line-feed ({@code '\n'}, U+000A) character.
+ * These characters are the classic vehicle for CRLF / header-injection attacks
+ * when user-controlled input is written verbatim into an email header.</p>
+ *
+ * <p>Returns {@code true} for {@code null} values. Presence validation is
+ * delegated to {@link jakarta.validation.constraints.NotBlank} or
+ * {@link jakarta.validation.constraints.NotNull} so that each annotation retains
+ * a single, clear responsibility.</p>
+ *
+ * <p>The check intentionally uses {@link String#indexOf(int)} rather than a
+ * regex so that the hot path (no injection characters present) pays only two
+ * linear scans with no regex compilation or backtracking overhead.</p>
+ *
+ * @see NoHeaderInjection
+ */
+public class NoHeaderInjectionValidator implements ConstraintValidator<NoHeaderInjection, String> {
+
+    /**
+     * Initializes the validator. No state is required for this implementation.
+     *
+     * @param constraintAnnotation the annotation instance (unused)
+     */
+    @Override
+    public void initialize(NoHeaderInjection constraintAnnotation) {
+        // No initialization required; validator is stateless.
+    }
+
+    /**
+     * Returns {@code true} if {@code value} is {@code null} or contains neither
+     * {@code '\r'} nor {@code '\n'}; {@code false} otherwise.
+     *
+     * @param value   the string to inspect (may be {@code null})
+     * @param context the constraint validator context
+     * @return {@code true} when no header-injection characters are present
+     */
+    @Override
+    public boolean isValid(String value, ConstraintValidatorContext context) {
+        if (value == null) {
+            return true;
+        }
+        return value.indexOf('\r') < 0 && value.indexOf('\n') < 0;
+    }
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjectionValidator.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjectionValidator.java
@@ -6,10 +6,23 @@ import jakarta.validation.ConstraintValidatorContext;
 /**
  * Validator for the {@link NoHeaderInjection} constraint.
  *
- * <p>Returns {@code false} when the supplied string contains a carriage-return
- * ({@code '\r'}, U+000D) or a line-feed ({@code '\n'}, U+000A) character.
- * These characters are the classic vehicle for CRLF / header-injection attacks
- * when user-controlled input is written verbatim into an email header.</p>
+ * <p>Returns {@code false} when the supplied string contains any Unicode
+ * line-terminator character. The full set of rejected characters is:</p>
+ * <ul>
+ *   <li>U+000A LINE FEED ({@code '\n'})</li>
+ *   <li>U+000B VERTICAL TAB ({@code ''})</li>
+ *   <li>U+000C FORM FEED ({@code ''})</li>
+ *   <li>U+000D CARRIAGE RETURN ({@code '\r'})</li>
+ *   <li>U+0085 NEXT LINE ({@code ''})</li>
+ *   <li>U+2028 LINE SEPARATOR ({@code ' '})</li>
+ *   <li>U+2029 PARAGRAPH SEPARATOR ({@code ' '})</li>
+ * </ul>
+ *
+ * <p>U+000A and U+000D are the classic CRLF / header-injection vehicles.
+ * The remaining five characters are defence-in-depth: they are recognised as
+ * line terminators by the Unicode Standard, the Java Language Specification,
+ * and various parsers, so removing any dependency on downstream encoding
+ * behaviour (e.g. RFC 2047 folding) is cheap and prudent.</p>
  *
  * <p>Returns {@code true} for {@code null} values. Presence validation is
  * delegated to {@link jakarta.validation.constraints.NotBlank} or
@@ -17,8 +30,8 @@ import jakarta.validation.ConstraintValidatorContext;
  * a single, clear responsibility.</p>
  *
  * <p>The check intentionally uses {@link String#indexOf(int)} rather than a
- * regex so that the hot path (no injection characters present) pays only two
- * linear scans with no regex compilation or backtracking overhead.</p>
+ * regex so that the hot path (no injection characters present) pays only linear
+ * scans with no regex compilation or backtracking overhead.</p>
  *
  * @see NoHeaderInjection
  */
@@ -35,18 +48,28 @@ public class NoHeaderInjectionValidator implements ConstraintValidator<NoHeaderI
     }
 
     /**
-     * Returns {@code true} if {@code value} is {@code null} or contains neither
-     * {@code '\r'} nor {@code '\n'}; {@code false} otherwise.
+     * Returns {@code true} if {@code value} is {@code null} or contains no
+     * Unicode line-terminator character; {@code false} otherwise.
+     *
+     * <p>The seven characters checked are U+000A, U+000B, U+000C, U+000D,
+     * U+0085, U+2028, and U+2029 — the complete set recognised as line
+     * terminators by the Unicode Standard and the Java Language Specification.</p>
      *
      * @param value   the string to inspect (may be {@code null})
      * @param context the constraint validator context
-     * @return {@code true} when no header-injection characters are present
+     * @return {@code true} when no line-terminator characters are present
      */
     @Override
     public boolean isValid(String value, ConstraintValidatorContext context) {
         if (value == null) {
             return true;
         }
-        return value.indexOf('\r') < 0 && value.indexOf('\n') < 0;
+        return value.indexOf('\n')      < 0  // U+000A LINE FEED
+            && value.indexOf('')  < 0  // U+000B VERTICAL TAB
+            && value.indexOf('')  < 0  // U+000C FORM FEED
+            && value.indexOf('\r')      < 0  // U+000D CARRIAGE RETURN
+            && value.indexOf('')  < 0  // U+0085 NEXT LINE
+            && value.indexOf(' ')  < 0  // U+2028 LINE SEPARATOR
+            && value.indexOf(' ')  < 0; // U+2029 PARAGRAPH SEPARATOR
     }
 }

--- a/src/main/java/com/aucontraire/gmailbuddy/validation/OptionalEmail.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/validation/OptionalEmail.java
@@ -15,7 +15,7 @@ import java.lang.annotation.*;
  */
 @Documented
 @Constraint(validatedBy = OptionalEmailValidator.class)
-@Target({ElementType.FIELD, ElementType.PARAMETER})
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface OptionalEmail {
     /**

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -48,6 +48,15 @@ gmail-buddy.gmail-api.query-operators.and=\\ AND\\
 gmail-buddy.oauth2.client-registration-id=google
 gmail-buddy.oauth2.token.prefix=Bearer
 
+# Send/Draft Endpoint Configuration
+gmail-buddy.send.max-body-size=10MB
+gmail-buddy.send.max-recipients-per-message=500
+gmail-buddy.send.max-subject-length=998
+
+# Multipart Configuration (explicit; aligns with gmail-buddy.send.max-body-size)
+spring.servlet.multipart.max-request-size=10MB
+spring.servlet.multipart.max-file-size=10MB
+
 # Application Rate Limiting Configuration
 gmail-buddy.application-rate-limit.requests-per-window=1000
 gmail-buddy.application-rate-limit.window-size-seconds=60
@@ -85,7 +94,7 @@ gmail-buddy.environment.env-file.name=.env
 
 spring.security.oauth2.client.registration.google.client-id=${GOOGLE_CLIENT_ID:YOUR_CLIENT_ID}
 spring.security.oauth2.client.registration.google.client-secret=${GOOGLE_CLIENT_SECRET:YOUR_CLIENT_SECRET}
-spring.security.oauth2.client.registration.google.scope=email,profile,https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://mail.google.com
+spring.security.oauth2.client.registration.google.scope=email,profile,https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://mail.google.com/
 spring.security.oauth2.client.registration.google.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
 spring.security.oauth2.client.provider.google.token-uri=https://oauth2.googleapis.com/token
 spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/auth

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,8 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <configuration>
+    <!--
+        Log-injection prevention (FR-024).
+        CrlfSanitizingMessageConverter replaces %msg in the encoder pattern.
+        It escapes \r and \n in every log message so that user-supplied strings
+        (recipient addresses, subject lines, validation-rejection values, Gmail
+        query strings built from request fields) cannot inject synthetic log lines.
+        Using a converter rather than per-call-site sanitization ensures that no
+        log.info(...) call can bypass the protection by forgetting to invoke a
+        helper method.
+    -->
+    <conversionRule conversionWord="sanitizedMsg"
+                    converterClass="com.aucontraire.gmailbuddy.util.CrlfSanitizingMessageConverter"/>
+
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd HH:mm:ss} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd HH:mm:ss} - %sanitizedMsg%n</pattern>
         </encoder>
     </appender>
 

--- a/src/test/java/com/aucontraire/gmailbuddy/config/ConfigurationPropertiesConfig.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/config/ConfigurationPropertiesConfig.java
@@ -2,21 +2,32 @@ package com.aucontraire.gmailbuddy.config;
 
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
-import jakarta.validation.Validation;
 import jakarta.validation.Validator;
-import jakarta.validation.ValidatorFactory;
 
 /**
  * Test configuration for configuration properties tests.
  * Provides the required Validator bean for property validation testing.
+ *
+ * <p>Uses {@link LocalValidatorFactoryBean} rather than
+ * {@code Validation.buildDefaultValidatorFactory()} so that the produced
+ * {@link Validator} is backed by Spring's {@code SpringConstraintValidatorFactory}.
+ * That factory is what allows {@code ConstraintValidator} implementations such as
+ * {@link com.aucontraire.gmailbuddy.validation.MaxBodySizeValidator} to receive
+ * {@code @Autowired} dependencies from the Spring application context. A plain
+ * Hibernate {@code ValidatorFactory} (the previous implementation) does not
+ * participate in Spring's dependency-injection lifecycle, so any validator that
+ * uses {@code @Autowired} field injection would see {@code null} for those fields,
+ * causing a {@link NullPointerException} inside {@code isValid}.</p>
  */
 @TestConfiguration
 public class ConfigurationPropertiesConfig {
 
     @Bean
     public Validator validator() {
-        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
-        return factory.getValidator();
+        LocalValidatorFactoryBean factory = new LocalValidatorFactoryBean();
+        factory.afterPropertiesSet();
+        return factory;
     }
 }

--- a/src/test/java/com/aucontraire/gmailbuddy/config/GmailBuddyPropertiesTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/config/GmailBuddyPropertiesTest.java
@@ -12,6 +12,7 @@ import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import java.util.Map;
 import java.util.Set;
+import org.springframework.util.unit.DataSize;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
@@ -195,9 +196,10 @@ class GmailBuddyPropertiesTest {
                 properties.validation(),
                 properties.security(),
                 properties.environment(),
-                properties.applicationRateLimit()
+                properties.applicationRateLimit(),
+                new GmailBuddyProperties.Send(DataSize.ofMegabytes(10), 500, 998)
         );
-        
+
         Set<ConstraintViolation<GmailBuddyProperties>> violations = validator.validate(invalidProperties);
         assertFalse(violations.isEmpty());
         assertTrue(violations.stream().anyMatch(v -> v.getMessage().contains("blank")));
@@ -223,9 +225,10 @@ class GmailBuddyPropertiesTest {
                 properties.validation(),
                 properties.security(),
                 properties.environment(),
-                properties.applicationRateLimit()
+                properties.applicationRateLimit(),
+                new GmailBuddyProperties.Send(DataSize.ofMegabytes(10), 500, 998)
         );
-        
+
         Set<ConstraintViolation<GmailBuddyProperties>> violations = validator.validate(invalidProperties);
         assertFalse(violations.isEmpty());
         assertTrue(violations.stream().anyMatch(v -> v.getMessage().contains("1")));
@@ -257,9 +260,10 @@ class GmailBuddyPropertiesTest {
                 properties.validation(),
                 properties.security(),
                 properties.environment(),
-                properties.applicationRateLimit()
+                properties.applicationRateLimit(),
+                new GmailBuddyProperties.Send(DataSize.ofMegabytes(10), 500, 998)
         );
-        
+
         Set<ConstraintViolation<GmailBuddyProperties>> violations = validator.validate(invalidProperties);
         assertFalse(violations.isEmpty());
         assertTrue(violations.stream().anyMatch(v -> v.getMessage().contains("positive") || v.getPropertyPath().toString().contains("defaultRetrySeconds")));

--- a/src/test/java/com/aucontraire/gmailbuddy/config/TokenAuthenticationFilterSecurityTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/config/TokenAuthenticationFilterSecurityTest.java
@@ -16,6 +16,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 /**
@@ -98,7 +99,7 @@ class TokenAuthenticationFilterSecurityTest {
         assertThat(auth.getAuthorities().iterator().next().getAuthority()).isEqualTo("ROLE_API_USER");
 
         // Verify secure token reference was created
-        verify(tokenReferenceService).createTokenReference(TEST_TOKEN, TEST_USER_EMAIL);
+        verify(tokenReferenceService).createTokenReference(eq(TEST_TOKEN), eq(TEST_USER_EMAIL), anyString());
         verify(filterChain).doFilter(request, response);
     }
 
@@ -121,7 +122,7 @@ class TokenAuthenticationFilterSecurityTest {
 
         verify(tokenValidator).getTokenInfo(TEST_TOKEN);
         verify(tokenValidator).hasValidGmailScopes(anyString());
-        verify(tokenReferenceService).createTokenReference(TEST_TOKEN, TEST_USER_EMAIL);
+        verify(tokenReferenceService).createTokenReference(eq(TEST_TOKEN), eq(TEST_USER_EMAIL), anyString());
         verify(filterChain).doFilter(request, response);
     }
 
@@ -245,7 +246,7 @@ class TokenAuthenticationFilterSecurityTest {
         // Arrange
         setupValidTokenRequest();
         setupValidTokenValidator();
-        when(tokenReferenceService.createTokenReference(TEST_TOKEN, TEST_USER_EMAIL))
+        when(tokenReferenceService.createTokenReference(eq(TEST_TOKEN), eq(TEST_USER_EMAIL), anyString()))
                 .thenThrow(new RuntimeException("Token reference creation failed"));
 
         // Act
@@ -257,7 +258,7 @@ class TokenAuthenticationFilterSecurityTest {
 
         verify(tokenValidator).getTokenInfo(TEST_TOKEN);
         verify(tokenValidator).hasValidGmailScopes(anyString());
-        verify(tokenReferenceService).createTokenReference(TEST_TOKEN, TEST_USER_EMAIL);
+        verify(tokenReferenceService).createTokenReference(eq(TEST_TOKEN), eq(TEST_USER_EMAIL), anyString());
         verify(response).setStatus(401);
     }
 
@@ -283,7 +284,7 @@ class TokenAuthenticationFilterSecurityTest {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         assertThat(auth).isNotNull();
         assertThat(auth.getPrincipal()).isEqualTo("user123");
-        verify(tokenReferenceService).createTokenReference(TEST_TOKEN, "user123");
+        verify(tokenReferenceService).createTokenReference(eq(TEST_TOKEN), eq("user123"), anyString());
     }
 
     @Test
@@ -308,7 +309,7 @@ class TokenAuthenticationFilterSecurityTest {
         Authentication auth = SecurityContextHolder.getContext().getAuthentication();
         assertThat(auth).isNotNull();
         assertThat(auth.getPrincipal()).isEqualTo("api-user");
-        verify(tokenReferenceService).createTokenReference(TEST_TOKEN, "api-user");
+        verify(tokenReferenceService).createTokenReference(eq(TEST_TOKEN), eq("api-user"), anyString());
     }
 
     @Test
@@ -325,7 +326,7 @@ class TokenAuthenticationFilterSecurityTest {
         when(tokenValidator.getTokenInfo(TEST_TOKEN)).thenReturn(tokenInfo);
 
         // Simulate token reference service failure
-        when(tokenReferenceService.createTokenReference(anyString(), anyString()))
+        when(tokenReferenceService.createTokenReference(anyString(), anyString(), anyString()))
                 .thenThrow(new RuntimeException("Simulated failure"));
 
         // Act & Assert - should not throw exception that could expose token
@@ -359,7 +360,7 @@ class TokenAuthenticationFilterSecurityTest {
 
     private void setupTokenReferenceServiceForUser(String userId) {
         when(tokenReference.getReferenceId()).thenReturn(TEST_REFERENCE_ID);
-        when(tokenReferenceService.createTokenReference(TEST_TOKEN, userId))
+        when(tokenReferenceService.createTokenReference(eq(TEST_TOKEN), eq(userId), anyString()))
                 .thenReturn(tokenReference);
     }
 }

--- a/src/test/java/com/aucontraire/gmailbuddy/config/TokenAuthenticationFilterTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/config/TokenAuthenticationFilterTest.java
@@ -94,7 +94,7 @@ class TokenAuthenticationFilterTest {
 
         // Setup default token reference mock behavior (lenient for tests that don't use them)
         lenient().when(tokenReference.getReferenceId()).thenReturn(TEST_REFERENCE_ID);
-        lenient().when(tokenReferenceService.createTokenReference(anyString(), anyString())).thenReturn(tokenReference);
+        lenient().when(tokenReferenceService.createTokenReference(anyString(), anyString(), anyString())).thenReturn(tokenReference);
     }
 
     @Nested
@@ -379,7 +379,7 @@ class TokenAuthenticationFilterTest {
                 return true;
             }));
             // Verify token reference was created
-            verify(tokenReferenceService).createTokenReference(VALID_BEARER_TOKEN, userEmail);
+            verify(tokenReferenceService).createTokenReference(eq(VALID_BEARER_TOKEN), eq(userEmail), anyString());
             verify(filterChain).doFilter(request, response);
         }
 

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/CreateDraftControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/CreateDraftControllerTest.java
@@ -1,0 +1,174 @@
+package com.aucontraire.gmailbuddy.controller;
+
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
+import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
+import com.aucontraire.gmailbuddy.ratelimit.RateLimitService;
+import com.aucontraire.gmailbuddy.security.TokenReferenceService;
+import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.GmailService;
+import com.aucontraire.gmailbuddy.service.GoogleTokenValidator;
+import com.aucontraire.gmailbuddy.validation.TestGmailBuddyPropertiesConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Controller-slice test for {@code POST /api/v1/gmail/drafts} — success contract.
+ *
+ * <p>Focuses exclusively on the 201 Created response shape per the API contract
+ * in {@code specs/001-send-draft-emails/contracts/api-endpoints.md § Endpoint 2}.
+ * Validation failure cases are covered separately in
+ * {@code SendMessageValidationTest} (T033); this test does not duplicate them.</p>
+ *
+ * <p>Uses {@code @WebMvcTest} (web layer only) with {@code @MockitoBean GmailService}
+ * so the controller's dependency on the service is isolated. The
+ * {@code TestGmailBuddyPropertiesConfiguration} supplies a correctly wired
+ * {@link com.aucontraire.gmailbuddy.config.GmailBuddyProperties} bean matching
+ * the existing {@code ControllerValidationTest} import pattern.</p>
+ */
+@WebMvcTest(GmailController.class)
+@Import(TestGmailBuddyPropertiesConfiguration.class)
+@DisplayName("POST /api/v1/gmail/drafts — 201 success contract")
+class CreateDraftControllerTest {
+
+    private static final String DRAFTS_ENDPOINT = "/api/v1/gmail/drafts";
+
+    // Test-fixture draft identifiers — chosen to be unambiguous.
+    private static final String DRAFT_ID   = "r-9876543210";
+    private static final String MESSAGE_ID = "19a2b3c4d5e6f7g8";
+    private static final String THREAD_ID  = "19a2b3c4d5e6f7g8";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private GmailService gmailService;
+
+    @MockitoBean
+    private OAuth2AuthorizedClientService authorizedClientService;
+
+    @MockitoBean
+    private GoogleTokenValidator tokenValidator;
+
+    @MockitoBean
+    private TokenReferenceService tokenReferenceService;
+
+    @MockitoBean
+    private ResponseMapper responseMapper;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @MockitoBean
+    private GmailQuotaEstimator gmailQuotaEstimator;
+
+    // -------------------------------------------------------------------------
+    // 201 Created — response body contract
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_validRequest_returns201WithDraftIdMessageIdThreadIdAndDraftStatus")
+    void postDraft_validRequest_returns201WithDraftIdMessageIdThreadIdAndDraftStatus()
+            throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        String requestBody = objectMapper.writeValueAsString(dto);
+
+        DraftCreationResult stubResult =
+                new DraftCreationResult(DRAFT_ID, MESSAGE_ID, THREAD_ID);
+
+        // The controller uses properties.gmailApi().defaultUserId() = "me" from the
+        // TestGmailBuddyPropertiesConfiguration bean.
+        when(gmailService.createDraft(eq("me"), any(SendMessageDTO.class)))
+                .thenReturn(stubResult);
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.draftId").value(DRAFT_ID))
+                .andExpect(jsonPath("$.messageId").value(MESSAGE_ID))
+                .andExpect(jsonPath("$.threadId").value(THREAD_ID))
+                .andExpect(jsonPath("$.status").value("DRAFT"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 201 Created — Location header contract
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_validRequest_returns201WithLocationHeaderPointingToDraftId")
+    void postDraft_validRequest_returns201WithLocationHeaderPointingToDraftId() throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        String requestBody = objectMapper.writeValueAsString(dto);
+
+        DraftCreationResult stubResult =
+                new DraftCreationResult(DRAFT_ID, MESSAGE_ID, THREAD_ID);
+
+        when(gmailService.createDraft(eq("me"), any(SendMessageDTO.class)))
+                .thenReturn(stubResult);
+
+        // Act & Assert: Location header must point to /api/v1/gmail/drafts/{draftId}
+        // per the api-endpoints.md § Endpoint 2 success-response example.
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location", "/api/v1/gmail/drafts/" + DRAFT_ID));
+    }
+
+    // -------------------------------------------------------------------------
+    // 201 Created — HTML body request also succeeds
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_htmlBodyRequest_returns201WithDraftStatus")
+    void postDraft_htmlBodyRequest_returns201WithDraftStatus() throws Exception {
+        // Arrange: HTML-body fixture to confirm the endpoint does not reject html bodyType.
+        SendMessageDTO dto = SendMessageRequestFixtures.validHtmlBody();
+        String requestBody = objectMapper.writeValueAsString(dto);
+
+        DraftCreationResult stubResult =
+                new DraftCreationResult(DRAFT_ID, MESSAGE_ID, THREAD_ID);
+
+        when(gmailService.createDraft(eq("me"), any(SendMessageDTO.class)))
+                .thenReturn(stubResult);
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("DRAFT"));
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/SendDraftControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/SendDraftControllerTest.java
@@ -1,0 +1,151 @@
+package com.aucontraire.gmailbuddy.controller;
+
+import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
+import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
+import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
+import com.aucontraire.gmailbuddy.ratelimit.RateLimitService;
+import com.aucontraire.gmailbuddy.security.TokenReferenceService;
+import com.aucontraire.gmailbuddy.service.GmailService;
+import com.aucontraire.gmailbuddy.service.GoogleTokenValidator;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
+import com.aucontraire.gmailbuddy.validation.TestGmailBuddyPropertiesConfiguration;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Controller-slice test for {@code POST /api/v1/gmail/drafts/{draftId}/send}.
+ *
+ * <p>Focuses on the status-code contract (200 OK, NOT 201), the explicit
+ * absence of a {@code Location} header (per Decision 3 — state transition),
+ * and the 404 error path when the draft no longer exists.</p>
+ *
+ * <p>Uses {@code @WebMvcTest} (web layer only) with {@code @MockitoBean GmailService}
+ * so the controller's dependency on the service is isolated. Mirrors the pattern
+ * established by {@code CreateDraftControllerTest}.</p>
+ */
+@WebMvcTest(GmailController.class)
+@Import(TestGmailBuddyPropertiesConfiguration.class)
+@DisplayName("POST /api/v1/gmail/drafts/{draftId}/send — 200 success contract")
+class SendDraftControllerTest {
+
+    private static final String SEND_DRAFT_ENDPOINT = "/api/v1/gmail/drafts/{draftId}/send";
+
+    private static final String DRAFT_ID   = "r-9876543210";
+    private static final String MESSAGE_ID = "19a2b3c4d5e6f7g8";
+    private static final String THREAD_ID  = "thread-19a2b3c4d5e6f7g8";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GmailService gmailService;
+
+    @MockitoBean
+    private OAuth2AuthorizedClientService authorizedClientService;
+
+    @MockitoBean
+    private GoogleTokenValidator tokenValidator;
+
+    @MockitoBean
+    private TokenReferenceService tokenReferenceService;
+
+    @MockitoBean
+    private ResponseMapper responseMapper;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @MockitoBean
+    private GmailQuotaEstimator gmailQuotaEstimator;
+
+    // -------------------------------------------------------------------------
+    // 200 OK — correct status code (NOT 201)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postSendDraft_validDraftId_returns200NotCreated")
+    void postSendDraft_validDraftId_returns200NotCreated() throws Exception {
+        // Arrange
+        SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+        when(gmailService.sendDraft(eq("me"), eq(DRAFT_ID))).thenReturn(stubResult);
+
+        // Act & Assert: must be 200 OK, not 201 Created — state transition, not creation.
+        mockMvc.perform(post(SEND_DRAFT_ENDPOINT, DRAFT_ID).with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    // -------------------------------------------------------------------------
+    // 200 OK — Location header must be ABSENT
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postSendDraft_validDraftId_locationHeaderIsAbsent")
+    void postSendDraft_validDraftId_locationHeaderIsAbsent() throws Exception {
+        // Arrange
+        SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+        when(gmailService.sendDraft(eq("me"), eq(DRAFT_ID))).thenReturn(stubResult);
+
+        // Act & Assert: per contracts/api-endpoints.md Endpoint 3 — no Location header
+        // for a state transition (the draft is consumed; no new resource is created).
+        mockMvc.perform(post(SEND_DRAFT_ENDPOINT, DRAFT_ID).with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(header().doesNotExist("Location"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 200 OK — response body contract: {messageId, threadId, status: "SENT"}
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postSendDraft_validDraftId_returns200WithSendMessageResponseBody")
+    void postSendDraft_validDraftId_returns200WithSendMessageResponseBody() throws Exception {
+        // Arrange
+        SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+        when(gmailService.sendDraft(eq("me"), eq(DRAFT_ID))).thenReturn(stubResult);
+
+        // Act & Assert: response body must contain messageId, threadId, and status="SENT"
+        // per the api-endpoints.md Endpoint 3 success-response example.
+        mockMvc.perform(post(SEND_DRAFT_ENDPOINT, DRAFT_ID).with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.messageId").value(MESSAGE_ID))
+                .andExpect(jsonPath("$.threadId").value(THREAD_ID))
+                .andExpect(jsonPath("$.status").value("SENT"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 404 — draft not found / already sent or discarded
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postSendDraft_draftNotFound_returns404WithResourceNotFoundProblemType")
+    void postSendDraft_draftNotFound_returns404WithResourceNotFoundProblemType() throws Exception {
+        // Arrange: service throws ResourceNotFoundException when the draft no longer exists
+        // (already sent, discarded, or invalid draftId).
+        when(gmailService.sendDraft(eq("me"), eq(DRAFT_ID)))
+                .thenThrow(new ResourceNotFoundException("Draft not found or already sent/discarded"));
+
+        // Act & Assert: controller must surface 404 + RFC 7807 problem type.
+        mockMvc.perform(post(SEND_DRAFT_ENDPOINT, DRAFT_ID).with(csrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.type").value("/problems/resource-not-found"));
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/SendMessageControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/SendMessageControllerTest.java
@@ -1,0 +1,250 @@
+package com.aucontraire.gmailbuddy.controller;
+
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+import com.aucontraire.gmailbuddy.exception.ValidationException;
+import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
+import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
+import com.aucontraire.gmailbuddy.ratelimit.RateLimitService;
+import com.aucontraire.gmailbuddy.security.TokenReferenceService;
+import com.aucontraire.gmailbuddy.service.GmailService;
+import com.aucontraire.gmailbuddy.service.GoogleTokenValidator;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
+import com.aucontraire.gmailbuddy.validation.TestGmailBuddyPropertiesConfiguration;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Controller-slice test for {@code POST /api/v1/gmail/messages} — direct send.
+ *
+ * <p>Focuses on the critical contract differences from {@code CreateDraftControllerTest}:</p>
+ * <ul>
+ *   <li>HTTP 201 Created (same as drafts, but with a different Location)</li>
+ *   <li>Location header IS present and ends with {@code /body} per Decision 3 and
+ *       contracts/api-endpoints.md Endpoint 1</li>
+ *   <li>Response body: {@code {messageId, threadId, status: "SENT"}}</li>
+ *   <li>Validation failure (Gmail rejects recipient) → service throws
+ *       {@link ValidationException} → 400 with problem type</li>
+ * </ul>
+ *
+ * <p>Uses {@code @WebMvcTest} (web layer only) with {@code @MockitoBean GmailService}.
+ * Mirrors the pattern established by {@code CreateDraftControllerTest}.</p>
+ */
+@WebMvcTest(GmailController.class)
+@Import(TestGmailBuddyPropertiesConfiguration.class)
+@DisplayName("POST /api/v1/gmail/messages — 201 direct-send success contract")
+class SendMessageControllerTest {
+
+    private static final String MESSAGES_ENDPOINT = "/api/v1/gmail/messages";
+
+    private static final String MESSAGE_ID = "19a2b3c4d5e6f7g8";
+    private static final String THREAD_ID  = "thread-19a2b3c4d5e6f7g8";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private GmailService gmailService;
+
+    @MockitoBean
+    private OAuth2AuthorizedClientService authorizedClientService;
+
+    @MockitoBean
+    private GoogleTokenValidator tokenValidator;
+
+    @MockitoBean
+    private TokenReferenceService tokenReferenceService;
+
+    @MockitoBean
+    private ResponseMapper responseMapper;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @MockitoBean
+    private GmailQuotaEstimator gmailQuotaEstimator;
+
+    // -------------------------------------------------------------------------
+    // 201 Created — correct status code
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postSendMessage_validRequest_returns201Created")
+    void postSendMessage_validRequest_returns201Created() throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        String requestBody = objectMapper.writeValueAsString(dto);
+
+        SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+        when(gmailService.sendMessage(eq("me"), any(SendMessageDTO.class)))
+                .thenReturn(stubResult);
+
+        // Act & Assert: must be 201 Created (new message resource created per Decision 3).
+        mockMvc.perform(post(MESSAGES_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated());
+    }
+
+    // -------------------------------------------------------------------------
+    // 201 Created — Location header IS present and ends with /body
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postSendMessage_validRequest_returns201WithLocationHeaderEndingWithBody")
+    void postSendMessage_validRequest_returns201WithLocationHeaderEndingWithBody() throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        String requestBody = objectMapper.writeValueAsString(dto);
+
+        SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+        when(gmailService.sendMessage(eq("me"), any(SendMessageDTO.class)))
+                .thenReturn(stubResult);
+
+        // Act & Assert: Location header must point to /api/v1/gmail/messages/{messageId}/body
+        // per contracts/api-endpoints.md Endpoint 1 and Decision 3.
+        mockMvc.perform(post(MESSAGES_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(header().string("Location",
+                        "/api/v1/gmail/messages/" + MESSAGE_ID + "/body"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 201 Created — response body contract: {messageId, threadId, status: "SENT"}
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postSendMessage_validRequest_returns201WithSendMessageResponseBody")
+    void postSendMessage_validRequest_returns201WithSendMessageResponseBody() throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        String requestBody = objectMapper.writeValueAsString(dto);
+
+        SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+        when(gmailService.sendMessage(eq("me"), any(SendMessageDTO.class)))
+                .thenReturn(stubResult);
+
+        // Act & Assert: response body must contain messageId, threadId, and status="SENT"
+        // per api-endpoints.md Endpoint 1 success-response example.
+        mockMvc.perform(post(MESSAGES_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.messageId").value(MESSAGE_ID))
+                .andExpect(jsonPath("$.threadId").value(THREAD_ID))
+                .andExpect(jsonPath("$.status").value("SENT"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Contrast with sendDraft: Location header must NOT be absent (positive check)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postSendMessage_validRequest_locationHeaderIsPresent")
+    void postSendMessage_validRequest_locationHeaderIsPresent() throws Exception {
+        // Arrange: explicit positive assertion complementing the sendDraft test that
+        // asserts Location is absent.  This test would fail if the controller returned
+        // 200 (like sendDraft) instead of 201 (which sets Location via ResponseEntity.created()).
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        String requestBody = objectMapper.writeValueAsString(dto);
+
+        SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+        when(gmailService.sendMessage(eq("me"), any(SendMessageDTO.class)))
+                .thenReturn(stubResult);
+
+        // Act & Assert
+        mockMvc.perform(post(MESSAGES_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(header().exists("Location"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 400 — Gmail rejects the recipient (ValidationException from service layer)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postSendMessage_gmailRejectsRecipient_returns400WithValidationErrorProblemType")
+    void postSendMessage_gmailRejectsRecipient_returns400WithValidationErrorProblemType()
+            throws Exception {
+        // Arrange: service throws ValidationException when Gmail returns 400 invalidArgument
+        // (mapped from mapGmailSendError in the repository layer and wrapped in GmailApiException
+        // at the service layer — but since ValidationException is a RuntimeException it propagates
+        // directly through the GmailApiException catch-block only for IOException).
+        // The repository throws ValidationException directly (it's a RuntimeException),
+        // which the service does NOT catch (only IOException is caught).
+        // GlobalExceptionHandler catches ValidationException → 400 + /problems/validation-error.
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        String requestBody = objectMapper.writeValueAsString(dto);
+
+        when(gmailService.sendMessage(eq("me"), any(SendMessageDTO.class)))
+                .thenThrow(new ValidationException(
+                        "Gmail rejected one or more recipient addresses or message fields"));
+
+        // Act & Assert
+        mockMvc.perform(post(MESSAGES_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("/problems/validation-error"));
+    }
+
+    // -------------------------------------------------------------------------
+    // 201 Created — HTML body request also succeeds
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postSendMessage_htmlBodyRequest_returns201WithSentStatus")
+    void postSendMessage_htmlBodyRequest_returns201WithSentStatus() throws Exception {
+        // Arrange: HTML-body fixture to confirm the endpoint does not reject html bodyType.
+        SendMessageDTO dto = SendMessageRequestFixtures.validHtmlBody();
+        String requestBody = objectMapper.writeValueAsString(dto);
+
+        SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+        when(gmailService.sendMessage(eq("me"), any(SendMessageDTO.class)))
+                .thenReturn(stubResult);
+
+        // Act & Assert
+        mockMvc.perform(post(MESSAGES_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("SENT"));
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/exception/MessageSendExceptionTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/exception/MessageSendExceptionTest.java
@@ -1,0 +1,110 @@
+package com.aucontraire.gmailbuddy.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DisplayName("MessageSendException Tests")
+class MessageSendExceptionTest {
+
+    // ---------------------------------------------------------------
+    // Constructor: MessageSendException(String message)
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("Constructor with message initialises error code, message, and correlation ID")
+    void constructor_WithMessageOnly_ShouldInitialiseFields() {
+        // Arrange
+        String message = "Gmail API rejected the send request";
+
+        // Act
+        MessageSendException exception = new MessageSendException(message);
+
+        // Assert
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getErrorCode()).isEqualTo("MESSAGE_SEND_FAILED");
+        assertThat(exception.getCorrelationId()).isNotNull().isNotEmpty();
+        assertThat(exception.getCause()).isNull();
+    }
+
+    // ---------------------------------------------------------------
+    // Constructor: MessageSendException(String message, Throwable cause)
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("Constructor with message and cause preserves the upstream cause")
+    void constructor_WithMessageAndCause_ShouldPreserveCause() {
+        // Arrange
+        String message = "Upstream Gmail API connection failed";
+        Throwable cause = new RuntimeException("socket timeout");
+
+        // Act
+        MessageSendException exception = new MessageSendException(message, cause);
+
+        // Assert
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getErrorCode()).isEqualTo("MESSAGE_SEND_FAILED");
+        assertThat(exception.getCause()).isSameAs(cause);
+        assertThat(exception.getCorrelationId()).isNotNull().isNotEmpty();
+    }
+
+    // ---------------------------------------------------------------
+    // Constructor: MessageSendException(String message, String correlationId)
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("Constructor with message and correlationId stores the supplied correlation ID")
+    void constructor_WithMessageAndCorrelationId_ShouldStoreCorrelationId() {
+        // Arrange
+        String message = "Send draft failed for traced request";
+        String correlationId = "trace-abc-123";
+
+        // Act
+        MessageSendException exception = new MessageSendException(message, correlationId);
+
+        // Assert
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getErrorCode()).isEqualTo("MESSAGE_SEND_FAILED");
+        assertThat(exception.getCorrelationId()).isEqualTo(correlationId);
+        assertThat(exception.getCause()).isNull();
+    }
+
+    // ---------------------------------------------------------------
+    // getHttpStatus()
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("getHttpStatus returns 502 Bad Gateway for all constructor variants")
+    void getHttpStatus_Always_ReturnsBadGateway502() {
+        // Arrange
+        MessageSendException fromMessage = new MessageSendException("send failed");
+        MessageSendException fromMessageAndCause =
+                new MessageSendException("send failed", new Exception("api error"));
+        MessageSendException fromMessageAndCorrelation =
+                new MessageSendException("send failed", "corr-id-999");
+
+        // Act & Assert
+        assertThat(fromMessage.getHttpStatus()).isEqualTo(HttpStatus.BAD_GATEWAY.value());
+        assertThat(fromMessageAndCause.getHttpStatus()).isEqualTo(HttpStatus.BAD_GATEWAY.value());
+        assertThat(fromMessageAndCorrelation.getHttpStatus()).isEqualTo(HttpStatus.BAD_GATEWAY.value());
+    }
+
+    // ---------------------------------------------------------------
+    // isClientError() — inherited final method from GmailBuddyServerException
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("isClientError returns false because the fault originates in Gmail API")
+    void isClientError_Always_ReturnsFalse() {
+        // Arrange
+        MessageSendException exception = new MessageSendException("upstream gmail failure");
+
+        // Act
+        boolean clientError = exception.isClientError();
+
+        // Assert
+        assertThat(clientError).isFalse();
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/fixture/SendMessageRequestFixtures.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/fixture/SendMessageRequestFixtures.java
@@ -1,0 +1,203 @@
+package com.aucontraire.gmailbuddy.fixture;
+
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+
+import java.util.List;
+
+/**
+ * Static factory methods that produce {@link SendMessageDTO} instances for use
+ * in unit and integration tests throughout the send-and-draft feature
+ * (Phase 2 Foundational, T028).
+ *
+ * <h2>Design</h2>
+ * <p>All methods are static. This class carries no Spring context
+ * ({@code @Component} is intentionally absent) so it can be used from any test
+ * layer — plain JUnit, {@code @WebMvcTest}, {@code @SpringBootTest} — without
+ * needing a running application context.</p>
+ *
+ * <h2>Naming conventions</h2>
+ * <p>Method names follow the pattern {@code valid*()} for DTOs that should pass
+ * Bean Validation, and {@code invalid*()} for DTOs that are expected to fail at
+ * least one constraint. This mirrors the convention used in other test helpers
+ * in this project (e.g., {@code TestTokenProvider}, {@code TestOAuth2AuthorizedClientService})
+ * where "configure*" / "with*" semantics make the intent obvious without
+ * requiring a doc comment to decode.</p>
+ *
+ * <h2>Oversized body note</h2>
+ * <p>{@link #invalidOversizedBody()} uses {@code String.repeat()} to
+ * produce a string that exceeds the 10 MB limit. A base unit of
+ * {@code "A".repeat(1024)} (1 KiB of ASCII — each character is exactly 1 UTF-8
+ * byte) repeated 10 241 times yields 10 240 KiB = 10 MB + 1 KiB, safely above
+ * the {@code gmail-buddy.send.max-body-size=10MB} ceiling without materialising
+ * a huge string literal in source code. The JVM allocates this lazily via the
+ * compact String implementation; actual heap cost is ~10 MB for the duration of
+ * the test.</p>
+ *
+ * <p>Used by: T029–T032, T033–T036, T041, T044, T048–T051.</p>
+ */
+public final class SendMessageRequestFixtures {
+
+    // Convenient shared constants for reuse across factory methods.
+    private static final String VALID_SINGLE_RECIPIENT = "recruiter@example.com";
+    private static final String VALID_SUBJECT = "Software Engineer – Application Follow-up";
+    private static final String VALID_TEXT_BODY =
+            "Hi there,\n\nI wanted to follow up on my application for the Software Engineer role.\n\nBest regards";
+    private static final String VALID_HTML_BODY =
+            "<p>Hi there,</p><p>I wanted to follow up on my application for the "
+            + "<strong>Software Engineer</strong> role.</p><p>Best regards</p>";
+
+    // Utility class — no instances.
+    private SendMessageRequestFixtures() {
+        throw new AssertionError(
+                "SendMessageRequestFixtures is a static factory class and must not be instantiated");
+    }
+
+    // -------------------------------------------------------------------------
+    // Valid fixtures
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a minimal, fully valid {@link SendMessageDTO} with a single primary
+     * recipient, no cc, no bcc, a plain-text body, and {@code bodyType} defaulted
+     * to {@code "text"}.
+     *
+     * <p>This is the baseline happy-path fixture used by most unit tests to
+     * establish that the system processes a well-formed request correctly.</p>
+     *
+     * @return a valid single-recipient DTO
+     */
+    public static SendMessageDTO validSingleRecipient() {
+        return new SendMessageDTO(
+                List.of(VALID_SINGLE_RECIPIENT),
+                null,   // compact constructor normalises to List.of()
+                null,   // compact constructor normalises to List.of()
+                VALID_SUBJECT,
+                VALID_TEXT_BODY,
+                null    // compact constructor defaults to "text"
+        );
+    }
+
+    /**
+     * Returns a valid {@link SendMessageDTO} with multiple primary recipients and
+     * non-empty {@code cc} and {@code bcc} lists, simulating a real outreach blast.
+     *
+     * <p>Use this fixture for tests that must verify per-element validation across
+     * all three recipient fields, and for tests that assert the MimeMessage
+     * construction handles multi-address headers (comma-separated values) correctly.</p>
+     *
+     * @return a valid multi-recipient DTO with cc and bcc populated
+     */
+    public static SendMessageDTO validMultiRecipientWithCcAndBcc() {
+        return new SendMessageDTO(
+                List.of("alice@example.com", "bob@example.com"),
+                List.of("cc-recipient@example.com"),
+                List.of("bcc-recipient@example.com"),
+                VALID_SUBJECT,
+                VALID_TEXT_BODY,
+                "text"
+        );
+    }
+
+    /**
+     * Returns a valid {@link SendMessageDTO} with an HTML body and
+     * {@code bodyType} explicitly set to {@code "html"}.
+     *
+     * <p>Use this fixture for tests that exercise the HTML pass-through path:
+     * the service must forward the HTML body verbatim to the Gmail API without
+     * sanitization (spec Decision 7, FR-014). Also useful for
+     * {@code MimeMessageBuilderTest} to assert {@code Content-Type: text/html}
+     * is set on the resulting {@link jakarta.mail.internet.MimeMessage}.</p>
+     *
+     * @return a valid single-recipient DTO whose body is HTML
+     */
+    public static SendMessageDTO validHtmlBody() {
+        return new SendMessageDTO(
+                List.of(VALID_SINGLE_RECIPIENT),
+                null,
+                null,
+                VALID_SUBJECT,
+                VALID_HTML_BODY,
+                "html"
+        );
+    }
+
+    // -------------------------------------------------------------------------
+    // Invalid fixtures — expected to fail Bean Validation
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a {@link SendMessageDTO} whose {@code subject} contains a CRLF
+     * sequence ({@code \r\n}), which is a header-injection attempt per FR-015.
+     *
+     * <p>This fixture is used by {@code @NoHeaderInjection} validator tests
+     * (T029) and by controller/validation-slice tests (T033) to assert that:</p>
+     * <ol>
+     *   <li>The request is rejected before any MimeMessage is constructed or any
+     *       Gmail API call is made.</li>
+     *   <li>The error response uses the problem type
+     *       {@code /problems/header-injection-detected} — distinct from the
+     *       generic {@code /problems/validation-error}.</li>
+     * </ol>
+     *
+     * @return an otherwise-valid DTO whose subject line carries CRLF characters
+     */
+    public static SendMessageDTO invalidCrlfInSubject() {
+        return new SendMessageDTO(
+                List.of(VALID_SINGLE_RECIPIENT),
+                null,
+                null,
+                "Legitimate Subject\r\nX-Injected-Header: malicious",
+                VALID_TEXT_BODY,
+                "text"
+        );
+    }
+
+    /**
+     * Returns a {@link SendMessageDTO} with an empty {@code to} list, which must
+     * be rejected by {@code @NotEmpty} per FR-009.
+     *
+     * <p>The compact constructor receives an explicit empty list here (rather than
+     * {@code null}) to exercise the {@code @NotEmpty} constraint directly rather
+     * than the null-normalisation path. Tests asserting on this fixture should
+     * expect an HTTP 400 response with a field error on {@code to}.</p>
+     *
+     * @return a DTO with no primary recipients
+     */
+    public static SendMessageDTO invalidEmptyToList() {
+        return new SendMessageDTO(
+                List.of(),   // @NotEmpty should reject this
+                null,
+                null,
+                VALID_SUBJECT,
+                VALID_TEXT_BODY,
+                "text"
+        );
+    }
+
+    /**
+     * Returns a {@link SendMessageDTO} with a body that exceeds the 10 MB
+     * {@code @MaxBodySize} limit per FR-013.
+     *
+     * <p>Implementation note: a base unit of {@code "A".repeat(1024)} (1 KiB of
+     * single-byte ASCII characters) repeated 10 241 times yields 10 241 KiB,
+     * which is exactly 1 KiB above the 10 MB ceiling. Each {@code 'A'} is a
+     * single-byte UTF-8 sequence, so byte length equals character length —
+     * making the byte arithmetic straightforward and the test deterministic
+     * regardless of platform or locale.</p>
+     *
+     * @return a DTO whose body UTF-8 byte length exceeds 10 MB
+     */
+    public static SendMessageDTO invalidOversizedBody() {
+        // 1 KiB unit (1 024 ASCII bytes, each 1 UTF-8 byte) × 10 241 = 10 484 736 bytes
+        // > 10 MB (10 485 760 bytes) — reliably above the limit.
+        String oversizedBody = "A".repeat(1024).repeat(10_241);
+        return new SendMessageDTO(
+                List.of(VALID_SINGLE_RECIPIENT),
+                null,
+                null,
+                VALID_SUBJECT,
+                oversizedBody,
+                "text"
+        );
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/integration/CreateDraftIntegrationTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/integration/CreateDraftIntegrationTest.java
@@ -1,0 +1,258 @@
+package com.aucontraire.gmailbuddy.integration;
+
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.repository.GmailRepository;
+import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.GmailService;
+import com.aucontraire.gmailbuddy.service.GoogleTokenValidator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for {@code POST /api/v1/gmail/drafts} with the full Spring
+ * application context.
+ *
+ * <p>Two {@code @Nested} classes exercise the two supported authentication paths:</p>
+ * <ol>
+ *   <li><strong>Bearer-token path</strong> — mirrors the service-to-service caller.
+ *       The {@code GoogleTokenValidator} is mocked to return a valid token info, so
+ *       {@code TokenAuthenticationFilter} allows the request through without a real
+ *       Google token. This matches the pattern in
+ *       {@code ApiClientAuthenticationIntegrationTest}.</li>
+ *   <li><strong>Session / {@code @WithMockUser} path</strong> — mirrors the
+ *       browser-session caller. Spring Security Test injects a mock user into the
+ *       security context so the OAuth2 redirect is bypassed.</li>
+ * </ol>
+ *
+ * <p>Both paths assert the 201 Created status + {@code DraftResponse} body contract.
+ * {@code GmailService} is mocked so no Gmail API calls are made.</p>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("POST /api/v1/gmail/drafts — integration")
+class CreateDraftIntegrationTest {
+
+    // -------------------------------------------------------------------------
+    // Constants — shared across nested classes
+    // -------------------------------------------------------------------------
+
+    /**
+     * A realistic-looking (but fake) Google OAuth2 access token.
+     * The token starts with the {@code ya29.} prefix that the real Google tokens use,
+     * which is what the {@code TokenAuthenticationFilter} looks for when deciding
+     * whether to invoke {@code GoogleTokenValidator}.
+     */
+    static final String VALID_GOOGLE_TOKEN = "ya29.a0ARrdaM-valid-google-token-for-draft";
+
+    private static final String DRAFTS_ENDPOINT = "/api/v1/gmail/drafts";
+    private static final String DRAFT_ID        = "r-9876543210";
+    private static final String MESSAGE_ID      = "19a2b3c4d5e6f7g8";
+    private static final String THREAD_ID       = "19a2b3c4d5e6f7g8";
+
+    // -------------------------------------------------------------------------
+    // Spring-managed beans
+    // -------------------------------------------------------------------------
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private GoogleTokenValidator tokenValidator;
+
+    @MockitoBean
+    private GmailService gmailService;
+
+    @MockitoBean
+    private GmailRepository gmailRepository;
+
+    @BeforeEach
+    void resetMocks() {
+        reset(tokenValidator, gmailService, gmailRepository);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: mock a valid token validation response (mirrors ApiClientAuthenticationIntegrationTest)
+    // -------------------------------------------------------------------------
+
+    /**
+     * Sets up the {@link GoogleTokenValidator} mock to behave as if the token is
+     * valid with required Gmail scopes, and stubs {@code GmailService.createDraft}
+     * to return a canned {@link DraftCreationResult}. This helper is the
+     * create-draft analogue of {@code mockValidTokenResponse()} in
+     * {@code ApiClientAuthenticationIntegrationTest}.
+     */
+    private void mockValidTokenResponseForDraft() throws Exception {
+        GoogleTokenValidator.TokenInfoResponse tokenInfo =
+                createValidTokenInfo();
+        when(tokenValidator.getTokenInfo(VALID_GOOGLE_TOKEN)).thenReturn(tokenInfo);
+        when(tokenValidator.hasValidGmailScopes(tokenInfo.getScope())).thenReturn(true);
+
+        DraftCreationResult stubResult =
+                new DraftCreationResult(DRAFT_ID, MESSAGE_ID, THREAD_ID);
+        when(gmailService.createDraft(anyString(), any(SendMessageDTO.class)))
+                .thenReturn(stubResult);
+    }
+
+    private GoogleTokenValidator.TokenInfoResponse createValidTokenInfo() {
+        GoogleTokenValidator.TokenInfoResponse tokenInfo =
+                new GoogleTokenValidator.TokenInfoResponse();
+        tokenInfo.setEmail("api-user@example.com");
+        tokenInfo.setUserId("123456789");
+        tokenInfo.setScope(
+                "https://www.googleapis.com/auth/gmail.readonly "
+                + "https://www.googleapis.com/auth/gmail.modify "
+                + "https://www.googleapis.com/auth/gmail.send");
+        tokenInfo.setAudience("test-client-id");
+        tokenInfo.setExpiresIn("3600");
+        tokenInfo.setAccessType("offline");
+        return tokenInfo;
+    }
+
+    // =========================================================================
+    // Nested class 1: Bearer-token authentication path
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Bearer-token auth path")
+    class BearerTokenAuthTests {
+
+        @Test
+        @DisplayName("postDraft_bearerTokenAuth_validRequest_returns201WithDraftResponseBody")
+        void postDraft_bearerTokenAuth_validRequest_returns201WithDraftResponseBody()
+                throws Exception {
+            // Arrange
+            mockValidTokenResponseForDraft();
+            SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+            String requestBody = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert
+            mockMvc.perform(post(DRAFTS_ENDPOINT)
+                            .header("Authorization", "Bearer " + VALID_GOOGLE_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.draftId").value(DRAFT_ID))
+                    .andExpect(jsonPath("$.messageId").value(MESSAGE_ID))
+                    .andExpect(jsonPath("$.threadId").value(THREAD_ID))
+                    .andExpect(jsonPath("$.status").value("DRAFT"));
+        }
+
+        @Test
+        @DisplayName("postDraft_bearerTokenAuth_validRequest_returns201WithLocationHeader")
+        void postDraft_bearerTokenAuth_validRequest_returns201WithLocationHeader()
+                throws Exception {
+            // Arrange
+            mockValidTokenResponseForDraft();
+            SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+            String requestBody = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert: Location header must point to /api/v1/gmail/drafts/{draftId}.
+            mockMvc.perform(post(DRAFTS_ENDPOINT)
+                            .header("Authorization", "Bearer " + VALID_GOOGLE_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(header().string("Location",
+                            "/api/v1/gmail/drafts/" + DRAFT_ID));
+        }
+
+        @Test
+        @DisplayName("postDraft_bearerTokenAuth_htmlBodyRequest_returns201")
+        void postDraft_bearerTokenAuth_htmlBodyRequest_returns201() throws Exception {
+            // Arrange: verify HTML bodyType is accepted end-to-end via bearer auth.
+            mockValidTokenResponseForDraft();
+            SendMessageDTO dto = SendMessageRequestFixtures.validHtmlBody();
+            String requestBody = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert
+            mockMvc.perform(post(DRAFTS_ENDPOINT)
+                            .header("Authorization", "Bearer " + VALID_GOOGLE_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.status").value("DRAFT"));
+        }
+    }
+
+    // =========================================================================
+    // Nested class 2: Browser session / @WithMockUser authentication path
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Browser session auth path (@WithMockUser)")
+    class SessionAuthTests {
+
+        @Test
+        @WithMockUser
+        @DisplayName("postDraft_sessionAuth_validRequest_returns201WithDraftResponseBody")
+        void postDraft_sessionAuth_validRequest_returns201WithDraftResponseBody()
+                throws Exception {
+            // Arrange: no Bearer header; @WithMockUser injects a session principal.
+            DraftCreationResult stubResult =
+                    new DraftCreationResult(DRAFT_ID, MESSAGE_ID, THREAD_ID);
+            when(gmailService.createDraft(anyString(), any(SendMessageDTO.class)))
+                    .thenReturn(stubResult);
+
+            SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+            String requestBody = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert
+            mockMvc.perform(post(DRAFTS_ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.draftId").value(DRAFT_ID))
+                    .andExpect(jsonPath("$.messageId").value(MESSAGE_ID))
+                    .andExpect(jsonPath("$.threadId").value(THREAD_ID))
+                    .andExpect(jsonPath("$.status").value("DRAFT"));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("postDraft_sessionAuth_validRequest_returns201WithLocationHeader")
+        void postDraft_sessionAuth_validRequest_returns201WithLocationHeader()
+                throws Exception {
+            // Arrange
+            DraftCreationResult stubResult =
+                    new DraftCreationResult(DRAFT_ID, MESSAGE_ID, THREAD_ID);
+            when(gmailService.createDraft(anyString(), any(SendMessageDTO.class)))
+                    .thenReturn(stubResult);
+
+            SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+            String requestBody = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert
+            mockMvc.perform(post(DRAFTS_ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(header().string("Location",
+                            "/api/v1/gmail/drafts/" + DRAFT_ID));
+        }
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/integration/SendDraftIntegrationTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/integration/SendDraftIntegrationTest.java
@@ -1,0 +1,193 @@
+package com.aucontraire.gmailbuddy.integration;
+
+import com.aucontraire.gmailbuddy.repository.GmailRepository;
+import com.aucontraire.gmailbuddy.service.GmailService;
+import com.aucontraire.gmailbuddy.service.GoogleTokenValidator;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for {@code POST /api/v1/gmail/drafts/{draftId}/send} with
+ * the full Spring application context.
+ *
+ * <p>Two {@code @Nested} classes exercise the two supported authentication paths:</p>
+ * <ol>
+ *   <li><strong>Bearer-token path</strong> — mirrors the service-to-service caller.
+ *       {@code GoogleTokenValidator} is mocked to return a valid token info so
+ *       {@code TokenAuthenticationFilter} allows the request through.</li>
+ *   <li><strong>Session / {@code @WithMockUser} path</strong> — mirrors the
+ *       browser-session caller. Spring Security Test injects a mock user.</li>
+ * </ol>
+ *
+ * <p>Both paths assert the 200 OK status, correct body, and the explicit absence
+ * of a Location header. {@code GmailService} is mocked so no Gmail API calls
+ * are made.</p>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("POST /api/v1/gmail/drafts/{draftId}/send — integration")
+class SendDraftIntegrationTest {
+
+    // -------------------------------------------------------------------------
+    // Constants — shared across nested classes
+    // -------------------------------------------------------------------------
+
+    /**
+     * Realistic-looking (but fake) Google OAuth2 access token.
+     * The {@code ya29.} prefix triggers token validation in {@code TokenAuthenticationFilter}.
+     */
+    static final String VALID_GOOGLE_TOKEN = "ya29.a0ARrdaM-valid-google-token-for-send-draft";
+
+    private static final String SEND_DRAFT_ENDPOINT = "/api/v1/gmail/drafts/{draftId}/send";
+    private static final String DRAFT_ID             = "r-9876543210";
+    private static final String MESSAGE_ID           = "19a2b3c4d5e6f7g8";
+    private static final String THREAD_ID            = "thread-19a2b3c4d5e6f7g8";
+
+    // -------------------------------------------------------------------------
+    // Spring-managed beans
+    // -------------------------------------------------------------------------
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GoogleTokenValidator tokenValidator;
+
+    @MockitoBean
+    private GmailService gmailService;
+
+    @MockitoBean
+    private GmailRepository gmailRepository;
+
+    @BeforeEach
+    void resetMocks() {
+        reset(tokenValidator, gmailService, gmailRepository);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: mock a valid token validation response + stub GmailService
+    // (mirrors mockValidTokenResponseForDraft() in CreateDraftIntegrationTest)
+    // -------------------------------------------------------------------------
+
+    private void mockValidTokenResponseForSendDraft() throws Exception {
+        GoogleTokenValidator.TokenInfoResponse tokenInfo = createValidTokenInfo();
+        when(tokenValidator.getTokenInfo(VALID_GOOGLE_TOKEN)).thenReturn(tokenInfo);
+        when(tokenValidator.hasValidGmailScopes(tokenInfo.getScope())).thenReturn(true);
+
+        SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+        when(gmailService.sendDraft(anyString(), anyString())).thenReturn(stubResult);
+    }
+
+    private GoogleTokenValidator.TokenInfoResponse createValidTokenInfo() {
+        GoogleTokenValidator.TokenInfoResponse tokenInfo =
+                new GoogleTokenValidator.TokenInfoResponse();
+        tokenInfo.setEmail("api-user@example.com");
+        tokenInfo.setUserId("123456789");
+        tokenInfo.setScope(
+                "https://www.googleapis.com/auth/gmail.readonly "
+                + "https://www.googleapis.com/auth/gmail.modify "
+                + "https://www.googleapis.com/auth/gmail.send");
+        tokenInfo.setAudience("test-client-id");
+        tokenInfo.setExpiresIn("3600");
+        tokenInfo.setAccessType("offline");
+        return tokenInfo;
+    }
+
+    // =========================================================================
+    // Nested class 1: Bearer-token authentication path
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Bearer-token auth path")
+    class BearerTokenAuthTests {
+
+        @Test
+        @DisplayName("postSendDraft_bearerTokenAuth_validDraftId_returns200WithSentBody")
+        void postSendDraft_bearerTokenAuth_validDraftId_returns200WithSentBody()
+                throws Exception {
+            // Arrange
+            mockValidTokenResponseForSendDraft();
+
+            // Act & Assert: 200 OK with correct body.
+            mockMvc.perform(post(SEND_DRAFT_ENDPOINT, DRAFT_ID)
+                            .header("Authorization", "Bearer " + VALID_GOOGLE_TOKEN))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.messageId").value(MESSAGE_ID))
+                    .andExpect(jsonPath("$.threadId").value(THREAD_ID))
+                    .andExpect(jsonPath("$.status").value("SENT"));
+        }
+
+        @Test
+        @DisplayName("postSendDraft_bearerTokenAuth_validDraftId_locationHeaderIsAbsent")
+        void postSendDraft_bearerTokenAuth_validDraftId_locationHeaderIsAbsent()
+                throws Exception {
+            // Arrange
+            mockValidTokenResponseForSendDraft();
+
+            // Act & Assert: no Location header for a state transition
+            // (per contracts/api-endpoints.md Endpoint 3 and Decision 3).
+            mockMvc.perform(post(SEND_DRAFT_ENDPOINT, DRAFT_ID)
+                            .header("Authorization", "Bearer " + VALID_GOOGLE_TOKEN))
+                    .andExpect(status().isOk())
+                    .andExpect(header().doesNotExist("Location"));
+        }
+    }
+
+    // =========================================================================
+    // Nested class 2: Browser session / @WithMockUser authentication path
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Browser session auth path (@WithMockUser)")
+    class SessionAuthTests {
+
+        @Test
+        @WithMockUser
+        @DisplayName("postSendDraft_sessionAuth_validDraftId_returns200WithSentBody")
+        void postSendDraft_sessionAuth_validDraftId_returns200WithSentBody() throws Exception {
+            // Arrange: no Bearer header; @WithMockUser injects a session principal.
+            SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+            when(gmailService.sendDraft(anyString(), anyString())).thenReturn(stubResult);
+
+            // Act & Assert
+            mockMvc.perform(post(SEND_DRAFT_ENDPOINT, DRAFT_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.messageId").value(MESSAGE_ID))
+                    .andExpect(jsonPath("$.threadId").value(THREAD_ID))
+                    .andExpect(jsonPath("$.status").value("SENT"));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("postSendDraft_sessionAuth_validDraftId_locationHeaderIsAbsent")
+        void postSendDraft_sessionAuth_validDraftId_locationHeaderIsAbsent() throws Exception {
+            // Arrange
+            SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+            when(gmailService.sendDraft(anyString(), anyString())).thenReturn(stubResult);
+
+            // Act & Assert: Location header must be absent in both auth paths.
+            mockMvc.perform(post(SEND_DRAFT_ENDPOINT, DRAFT_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(header().doesNotExist("Location"));
+        }
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/integration/SendMessageIntegrationTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/integration/SendMessageIntegrationTest.java
@@ -1,0 +1,268 @@
+package com.aucontraire.gmailbuddy.integration;
+
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.repository.GmailRepository;
+import com.aucontraire.gmailbuddy.service.GmailService;
+import com.aucontraire.gmailbuddy.service.GoogleTokenValidator;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests for {@code POST /api/v1/gmail/messages} (direct send)
+ * with the full Spring application context.
+ *
+ * <p>Two {@code @Nested} classes exercise the two supported authentication paths:</p>
+ * <ol>
+ *   <li><strong>Bearer-token path</strong> — mirrors the service-to-service caller.
+ *       {@code GoogleTokenValidator} is mocked to return a valid token info so
+ *       {@code TokenAuthenticationFilter} allows the request through without a real
+ *       Google token. Matches the pattern in {@code ApiClientAuthenticationIntegrationTest}.</li>
+ *   <li><strong>Session / {@code @WithMockUser} path</strong> — mirrors the
+ *       browser-session caller. Spring Security Test injects a mock user.</li>
+ * </ol>
+ *
+ * <p>Both paths assert the 201 Created status, {@code SendMessageResponse} body
+ * contract, and the Location header ending with {@code /body}. {@code GmailService}
+ * is mocked so no Gmail API calls are made.</p>
+ *
+ * <p>An additional test exercises the at-least-once contract documentation: the
+ * endpoint MUST NOT include any idempotency-key header in its response, confirming
+ * the API makes no idempotency guarantee for {@code POST /messages} (Decision 6).</p>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("POST /api/v1/gmail/messages — integration")
+class SendMessageIntegrationTest {
+
+    // -------------------------------------------------------------------------
+    // Constants — shared across nested classes
+    // -------------------------------------------------------------------------
+
+    /**
+     * Realistic-looking (but fake) Google OAuth2 access token.
+     * The {@code ya29.} prefix triggers token validation in {@code TokenAuthenticationFilter}.
+     */
+    static final String VALID_GOOGLE_TOKEN = "ya29.a0ARrdaM-valid-google-token-for-send-msg";
+
+    private static final String MESSAGES_ENDPOINT = "/api/v1/gmail/messages";
+    private static final String MESSAGE_ID        = "19a2b3c4d5e6f7g8";
+    private static final String THREAD_ID         = "thread-19a2b3c4d5e6f7g8";
+
+    // -------------------------------------------------------------------------
+    // Spring-managed beans
+    // -------------------------------------------------------------------------
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private GoogleTokenValidator tokenValidator;
+
+    @MockitoBean
+    private GmailService gmailService;
+
+    @MockitoBean
+    private GmailRepository gmailRepository;
+
+    @BeforeEach
+    void resetMocks() {
+        reset(tokenValidator, gmailService, gmailRepository);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: mock a valid token validation response + stub GmailService
+    // (mirrors mockValidTokenResponseForDraft() in CreateDraftIntegrationTest)
+    // -------------------------------------------------------------------------
+
+    private void mockValidTokenResponseForSendMessage() throws Exception {
+        GoogleTokenValidator.TokenInfoResponse tokenInfo = createValidTokenInfo();
+        when(tokenValidator.getTokenInfo(VALID_GOOGLE_TOKEN)).thenReturn(tokenInfo);
+        when(tokenValidator.hasValidGmailScopes(tokenInfo.getScope())).thenReturn(true);
+
+        SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+        when(gmailService.sendMessage(anyString(), any(SendMessageDTO.class)))
+                .thenReturn(stubResult);
+    }
+
+    private GoogleTokenValidator.TokenInfoResponse createValidTokenInfo() {
+        GoogleTokenValidator.TokenInfoResponse tokenInfo =
+                new GoogleTokenValidator.TokenInfoResponse();
+        tokenInfo.setEmail("api-user@example.com");
+        tokenInfo.setUserId("123456789");
+        tokenInfo.setScope(
+                "https://www.googleapis.com/auth/gmail.readonly "
+                + "https://www.googleapis.com/auth/gmail.modify "
+                + "https://www.googleapis.com/auth/gmail.send");
+        tokenInfo.setAudience("test-client-id");
+        tokenInfo.setExpiresIn("3600");
+        tokenInfo.setAccessType("offline");
+        return tokenInfo;
+    }
+
+    // =========================================================================
+    // Nested class 1: Bearer-token authentication path
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Bearer-token auth path")
+    class BearerTokenAuthTests {
+
+        @Test
+        @DisplayName("postSendMessage_bearerTokenAuth_validRequest_returns201WithSentResponseBody")
+        void postSendMessage_bearerTokenAuth_validRequest_returns201WithSentResponseBody()
+                throws Exception {
+            // Arrange
+            mockValidTokenResponseForSendMessage();
+            SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+            String requestBody = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert
+            mockMvc.perform(post(MESSAGES_ENDPOINT)
+                            .header("Authorization", "Bearer " + VALID_GOOGLE_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.messageId").value(MESSAGE_ID))
+                    .andExpect(jsonPath("$.threadId").value(THREAD_ID))
+                    .andExpect(jsonPath("$.status").value("SENT"));
+        }
+
+        @Test
+        @DisplayName("postSendMessage_bearerTokenAuth_validRequest_returns201WithLocationHeaderEndingWithBody")
+        void postSendMessage_bearerTokenAuth_validRequest_returns201WithLocationHeaderEndingWithBody()
+                throws Exception {
+            // Arrange
+            mockValidTokenResponseForSendMessage();
+            SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+            String requestBody = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert: Location header must end with /body per Decision 3 and
+            // contracts/api-endpoints.md Endpoint 1.
+            mockMvc.perform(post(MESSAGES_ENDPOINT)
+                            .header("Authorization", "Bearer " + VALID_GOOGLE_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(header().string("Location",
+                            "/api/v1/gmail/messages/" + MESSAGE_ID + "/body"));
+        }
+
+        @Test
+        @DisplayName("postSendMessage_bearerTokenAuth_htmlBodyRequest_returns201")
+        void postSendMessage_bearerTokenAuth_htmlBodyRequest_returns201() throws Exception {
+            // Arrange: verify HTML bodyType is accepted end-to-end via bearer auth.
+            mockValidTokenResponseForSendMessage();
+            SendMessageDTO dto = SendMessageRequestFixtures.validHtmlBody();
+            String requestBody = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert
+            mockMvc.perform(post(MESSAGES_ENDPOINT)
+                            .header("Authorization", "Bearer " + VALID_GOOGLE_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.status").value("SENT"));
+        }
+
+        @Test
+        @DisplayName("postSendMessage_bearerTokenAuth_responseDoesNotIncludeIdempotencyKeyHeader")
+        void postSendMessage_bearerTokenAuth_responseDoesNotIncludeIdempotencyKeyHeader()
+                throws Exception {
+            // Arrange: documents the at-least-once contract from Decision 6 / FR-023.
+            // The endpoint makes no idempotency guarantee; the response must NOT carry
+            // any Idempotency-Key or X-Idempotency-Key header that would imply one.
+            mockValidTokenResponseForSendMessage();
+            SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+            String requestBody = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert
+            mockMvc.perform(post(MESSAGES_ENDPOINT)
+                            .header("Authorization", "Bearer " + VALID_GOOGLE_TOKEN)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(header().doesNotExist("Idempotency-Key"))
+                    .andExpect(header().doesNotExist("X-Idempotency-Key"));
+        }
+    }
+
+    // =========================================================================
+    // Nested class 2: Browser session / @WithMockUser authentication path
+    // =========================================================================
+
+    @Nested
+    @DisplayName("Browser session auth path (@WithMockUser)")
+    class SessionAuthTests {
+
+        @Test
+        @WithMockUser
+        @DisplayName("postSendMessage_sessionAuth_validRequest_returns201WithSentResponseBody")
+        void postSendMessage_sessionAuth_validRequest_returns201WithSentResponseBody()
+                throws Exception {
+            // Arrange: no Bearer header; @WithMockUser injects a session principal.
+            SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+            when(gmailService.sendMessage(anyString(), any(SendMessageDTO.class)))
+                    .thenReturn(stubResult);
+
+            SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+            String requestBody = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert
+            mockMvc.perform(post(MESSAGES_ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(jsonPath("$.messageId").value(MESSAGE_ID))
+                    .andExpect(jsonPath("$.threadId").value(THREAD_ID))
+                    .andExpect(jsonPath("$.status").value("SENT"));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("postSendMessage_sessionAuth_validRequest_returns201WithLocationHeaderEndingWithBody")
+        void postSendMessage_sessionAuth_validRequest_returns201WithLocationHeaderEndingWithBody()
+                throws Exception {
+            // Arrange
+            SentMessageResult stubResult = new SentMessageResult(MESSAGE_ID, THREAD_ID);
+            when(gmailService.sendMessage(anyString(), any(SendMessageDTO.class)))
+                    .thenReturn(stubResult);
+
+            SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+            String requestBody = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert
+            mockMvc.perform(post(MESSAGES_ENDPOINT)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(requestBody))
+                    .andExpect(status().isCreated())
+                    .andExpect(header().string("Location",
+                            "/api/v1/gmail/messages/" + MESSAGE_ID + "/body"));
+        }
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/mapper/GmailMessageMapperTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/mapper/GmailMessageMapperTest.java
@@ -1,0 +1,217 @@
+package com.aucontraire.gmailbuddy.mapper;
+
+import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
+import com.google.api.services.gmail.model.Draft;
+import com.google.api.services.gmail.model.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+/**
+ * Unit tests for {@link GmailMessageMapper}.
+ *
+ * <p>The mapper is a pure conversion utility with no external dependencies.
+ * Gmail SDK types ({@link Message}, {@link Draft}) are SDK POJOs — they need
+ * no mocking; instances are constructed directly using their setter API and
+ * asserted against the resulting domain records.</p>
+ *
+ * <p>Test naming follows the project convention:
+ * {@code methodName_stateUnderTest_expectedBehavior}.</p>
+ */
+class GmailMessageMapperTest {
+
+    private GmailMessageMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new GmailMessageMapper();
+    }
+
+    // -------------------------------------------------------------------------
+    // toSentMessageResult — happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toSentMessageResult_messageWithIdAndThreadId_returnsResultWithBothFields() {
+        // Arrange
+        Message gmailMessage = new Message();
+        gmailMessage.setId("msg-abc-123");
+        gmailMessage.setThreadId("thread-xyz-456");
+
+        // Act
+        SentMessageResult result = mapper.toSentMessageResult(gmailMessage);
+
+        // Assert
+        assertThat(result.messageId()).isEqualTo("msg-abc-123");
+        assertThat(result.threadId()).isEqualTo("thread-xyz-456");
+    }
+
+    @Test
+    void toSentMessageResult_messageWithDifferentIds_resultReflectsCorrectValues() {
+        // Arrange: verify no field swap — messageId maps to getId(), threadId to getThreadId().
+        Message gmailMessage = new Message();
+        gmailMessage.setId("message-id-sentinel");
+        gmailMessage.setThreadId("thread-id-sentinel");
+
+        // Act
+        SentMessageResult result = mapper.toSentMessageResult(gmailMessage);
+
+        // Assert
+        assertThat(result.messageId()).isEqualTo("message-id-sentinel");
+        assertThat(result.threadId()).isEqualTo("thread-id-sentinel");
+    }
+
+    @Test
+    void toSentMessageResult_messageWithNullThreadId_resultHasNullThreadId() {
+        // Arrange: Gmail may omit threadId in some edge-case responses;
+        // the mapper must not add a null-guard that replaces it with a default.
+        Message gmailMessage = new Message();
+        gmailMessage.setId("msg-no-thread");
+        // threadId intentionally not set — defaults to null
+
+        // Act
+        SentMessageResult result = mapper.toSentMessageResult(gmailMessage);
+
+        // Assert
+        assertThat(result.messageId()).isEqualTo("msg-no-thread");
+        assertThat(result.threadId()).isNull();
+    }
+
+    @Test
+    void toSentMessageResult_nullMessage_throwsNullPointerException() {
+        // Arrange: the Javadoc contracts that null is disallowed;
+        // passing null must propagate as NullPointerException (per @throws).
+
+        // Act + Assert
+        assertThatNullPointerException()
+                .isThrownBy(() -> mapper.toSentMessageResult(null));
+    }
+
+    // -------------------------------------------------------------------------
+    // toDraftCreationResult — happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toDraftCreationResult_draftWithAllFields_returnsResultWithAllThreeFields() {
+        // Arrange
+        Message nestedMessage = new Message();
+        nestedMessage.setId("msg-nested-789");
+        nestedMessage.setThreadId("thread-nested-012");
+
+        Draft draft = new Draft();
+        draft.setId("draft-abc-001");
+        draft.setMessage(nestedMessage);
+
+        // Act
+        DraftCreationResult result = mapper.toDraftCreationResult(draft);
+
+        // Assert
+        assertThat(result.draftId()).isEqualTo("draft-abc-001");
+        assertThat(result.messageId()).isEqualTo("msg-nested-789");
+        assertThat(result.threadId()).isEqualTo("thread-nested-012");
+    }
+
+    @Test
+    void toDraftCreationResult_draftWithDifferentIds_resultReflectsCorrectValues() {
+        // Arrange: verify no field swap between draftId, messageId, threadId.
+        Message nestedMessage = new Message();
+        nestedMessage.setId("message-id-sentinel");
+        nestedMessage.setThreadId("thread-id-sentinel");
+
+        Draft draft = new Draft();
+        draft.setId("draft-id-sentinel");
+        draft.setMessage(nestedMessage);
+
+        // Act
+        DraftCreationResult result = mapper.toDraftCreationResult(draft);
+
+        // Assert
+        assertThat(result.draftId()).isEqualTo("draft-id-sentinel");
+        assertThat(result.messageId()).isEqualTo("message-id-sentinel");
+        assertThat(result.threadId()).isEqualTo("thread-id-sentinel");
+    }
+
+    // -------------------------------------------------------------------------
+    // toDraftCreationResult — null nested Message (null-safety)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toDraftCreationResult_draftWithNullNestedMessage_messageIdIsNull() {
+        // Arrange: per the Javadoc, a null nested Message results in null messageId
+        // and threadId. This covers the defensive null-safety branch in the mapper.
+        Draft draft = new Draft();
+        draft.setId("draft-no-message");
+        // draft.setMessage() not called — nested Message is null
+
+        // Act
+        DraftCreationResult result = mapper.toDraftCreationResult(draft);
+
+        // Assert
+        assertThat(result.draftId()).isEqualTo("draft-no-message");
+        assertThat(result.messageId()).isNull();
+    }
+
+    @Test
+    void toDraftCreationResult_draftWithNullNestedMessage_threadIdIsNull() {
+        // Arrange
+        Draft draft = new Draft();
+        draft.setId("draft-no-message");
+        // draft.setMessage() not called — nested Message is null
+
+        // Act
+        DraftCreationResult result = mapper.toDraftCreationResult(draft);
+
+        // Assert
+        assertThat(result.threadId()).isNull();
+    }
+
+    @Test
+    void toDraftCreationResult_draftWithNullNestedMessage_draftIdStillPopulated() {
+        // Arrange: even with a null nested message, the draft's own ID must
+        // be present in the result — the null guard must not wipe the draftId.
+        Draft draft = new Draft();
+        draft.setId("draft-with-null-message");
+
+        // Act
+        DraftCreationResult result = mapper.toDraftCreationResult(draft);
+
+        // Assert
+        assertThat(result.draftId()).isEqualTo("draft-with-null-message");
+    }
+
+    @Test
+    void toDraftCreationResult_nullDraft_throwsNullPointerException() {
+        // Arrange: the Javadoc contracts that null draft is disallowed.
+
+        // Act + Assert
+        assertThatNullPointerException()
+                .isThrownBy(() -> mapper.toDraftCreationResult(null));
+    }
+
+    // -------------------------------------------------------------------------
+    // toDraftCreationResult — nested Message with null threadId
+    // -------------------------------------------------------------------------
+
+    @Test
+    void toDraftCreationResult_nestedMessageWithNullThreadId_resultHasNullThreadId() {
+        // Arrange: Gmail may omit threadId on the nested message in some responses.
+        Message nestedMessage = new Message();
+        nestedMessage.setId("msg-no-thread");
+        // threadId intentionally not set
+
+        Draft draft = new Draft();
+        draft.setId("draft-msg-no-thread");
+        draft.setMessage(nestedMessage);
+
+        // Act
+        DraftCreationResult result = mapper.toDraftCreationResult(draft);
+
+        // Assert
+        assertThat(result.draftId()).isEqualTo("draft-msg-no-thread");
+        assertThat(result.messageId()).isEqualTo("msg-no-thread");
+        assertThat(result.threadId()).isNull();
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplCreateDraftTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplCreateDraftTest.java
@@ -1,0 +1,316 @@
+package com.aucontraire.gmailbuddy.repository;
+
+import com.aucontraire.gmailbuddy.client.GmailBatchClient;
+import com.aucontraire.gmailbuddy.client.GmailClient;
+import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
+import com.aucontraire.gmailbuddy.exception.RateLimitException;
+import com.aucontraire.gmailbuddy.exception.ValidationException;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
+import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.TokenProvider;
+import com.aucontraire.gmailbuddy.util.MimeMessageTestUtil;
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.gmail.Gmail;
+import com.google.api.services.gmail.model.Draft;
+import com.google.api.services.gmail.model.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeUtility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link GmailRepositoryImpl#createDraft(String, MimeMessage)}.
+ *
+ * <p>Exercises the full Gmail API mock chain (Gmail → Users → Drafts → Create → execute)
+ * and verifies the three error-mapping paths for {@link GoogleJsonResponseException}.</p>
+ *
+ * <p>Each test follows Arrange-Act-Assert with clearly separated sections per
+ * Constitution §VIII.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GmailRepositoryImpl — createDraft")
+class GmailRepositoryImplCreateDraftTest {
+
+    // -------------------------------------------------------------------------
+    // Standard test constants
+    // -------------------------------------------------------------------------
+
+    private static final String TEST_USER_ID     = "me";
+    private static final String TEST_ACCESS_TOKEN = "test-access-token-abc";
+    private static final String TEST_DRAFT_ID    = "r-9876543210";
+    private static final String TEST_MESSAGE_ID  = "19a2b3c4d5e6f7g8";
+    private static final String TEST_THREAD_ID   = "19a2b3c4d5e6f7g8";
+
+    // -------------------------------------------------------------------------
+    // Mocks for the full Gmail service dependency chain
+    // -------------------------------------------------------------------------
+
+    @Mock private GmailClient gmailClient;
+    @Mock private GmailBatchClient gmailBatchClient;
+    @Mock private TokenProvider tokenProvider;
+    @Mock private GmailBuddyProperties properties;
+    @Mock private GmailMessageMapper gmailMessageMapper;
+
+    // Gmail API call chain
+    @Mock private Gmail gmail;
+    @Mock private Gmail.Users users;
+    @Mock private Gmail.Users.Drafts drafts;
+    @Mock private Gmail.Users.Drafts.Create draftsCreate;
+
+    private GmailRepositoryImpl repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new GmailRepositoryImpl(
+                gmailClient, gmailBatchClient, tokenProvider, properties, gmailMessageMapper);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: build a minimal MimeMessage for use in tests
+    // -------------------------------------------------------------------------
+
+    private MimeMessage buildTestMimeMessage() throws MessagingException {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage mimeMessage = new MimeMessage(session);
+        mimeMessage.setFrom(new InternetAddress("sender@example.com"));
+        mimeMessage.addRecipient(
+                MimeMessage.RecipientType.TO,
+                new InternetAddress("recruiter@example.com"));
+        mimeMessage.setSubject("Software Engineer – Application Follow-up");
+        mimeMessage.setText("Hi there, I wanted to follow up.");
+        mimeMessage.saveChanges();
+        return mimeMessage;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: set up the standard Gmail draft mock chain
+    // -------------------------------------------------------------------------
+
+    private void givenGmailDraftChainReturns(Draft createdDraft) throws Exception {
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.drafts()).thenReturn(drafts);
+        when(drafts.create(eq(TEST_USER_ID), any(Draft.class))).thenReturn(draftsCreate);
+        when(draftsCreate.execute()).thenReturn(createdDraft);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: build a GoogleJsonResponseException with a specific reason code
+    // -------------------------------------------------------------------------
+
+    private GoogleJsonResponseException buildGoogleJsonException(int statusCode, String reason) {
+        GoogleJsonError error = new GoogleJsonError();
+        error.setCode(statusCode);
+        error.setMessage("Gmail API error: " + reason);
+
+        GoogleJsonError.ErrorInfo errorInfo = new GoogleJsonError.ErrorInfo();
+        errorInfo.setReason(reason);
+        error.setErrors(java.util.List.of(errorInfo));
+
+        GoogleJsonResponseException exception = mock(GoogleJsonResponseException.class);
+        when(exception.getDetails()).thenReturn(error);
+        when(exception.getMessage()).thenReturn("Gmail API error: " + reason);
+        when(exception.getStatusCode()).thenReturn(statusCode);
+        return exception;
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createDraft_validMimeMessage_returnsDraftCreationResultWithCorrectIds")
+    void createDraft_validMimeMessage_returnsDraftCreationResultWithCorrectIds() throws Exception {
+        // Arrange
+        MimeMessage mimeMessage = buildTestMimeMessage();
+
+        Message nestedMessage = new Message().setId(TEST_MESSAGE_ID).setThreadId(TEST_THREAD_ID);
+        Draft createdDraft = new Draft().setId(TEST_DRAFT_ID).setMessage(nestedMessage);
+
+        givenGmailDraftChainReturns(createdDraft);
+
+        DraftCreationResult expectedResult =
+                new DraftCreationResult(TEST_DRAFT_ID, TEST_MESSAGE_ID, TEST_THREAD_ID);
+        when(gmailMessageMapper.toDraftCreationResult(createdDraft)).thenReturn(expectedResult);
+
+        // Act
+        DraftCreationResult result = repository.createDraft(TEST_USER_ID, mimeMessage);
+
+        // Assert
+        assertThat(result).isNotNull();
+        assertThat(result.draftId()).isEqualTo(TEST_DRAFT_ID);
+        assertThat(result.messageId()).isEqualTo(TEST_MESSAGE_ID);
+        assertThat(result.threadId()).isEqualTo(TEST_THREAD_ID);
+        verify(gmailMessageMapper).toDraftCreationResult(createdDraft);
+    }
+
+    @Test
+    @DisplayName("createDraft_validMimeMessage_base64UrlEncodedPayloadReconstitutesToCorrectMimeHeaders")
+    void createDraft_validMimeMessage_base64UrlEncodedPayloadReconstitutesToCorrectMimeHeaders()
+            throws Exception {
+        // Arrange: capture the Draft argument passed to drafts.create(…) so we can
+        // inspect the base64url-encoded raw payload and decode it back to a MimeMessage.
+        MimeMessage originalMimeMessage = buildTestMimeMessage();
+
+        Message nestedMessage = new Message().setId(TEST_MESSAGE_ID).setThreadId(TEST_THREAD_ID);
+        Draft createdDraft = new Draft().setId(TEST_DRAFT_ID).setMessage(nestedMessage);
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.drafts()).thenReturn(drafts);
+
+        ArgumentCaptor<Draft> draftCaptor = ArgumentCaptor.forClass(Draft.class);
+        when(drafts.create(eq(TEST_USER_ID), draftCaptor.capture())).thenReturn(draftsCreate);
+        when(draftsCreate.execute()).thenReturn(createdDraft);
+        when(gmailMessageMapper.toDraftCreationResult(createdDraft))
+                .thenReturn(new DraftCreationResult(TEST_DRAFT_ID, TEST_MESSAGE_ID, TEST_THREAD_ID));
+
+        // Act
+        repository.createDraft(TEST_USER_ID, originalMimeMessage);
+
+        // Assert: decode the base64url raw payload and verify subject + recipient.
+        Draft capturedDraft = draftCaptor.getValue();
+        assertThat(capturedDraft.getMessage()).isNotNull();
+        String raw = capturedDraft.getMessage().getRaw();
+        assertThat(raw).isNotBlank();
+
+        MimeMessage reconstituted = MimeMessageTestUtil.fromBase64Url(raw);
+        // getHeader returns the raw wire value which JavaMail RFC 2047 Q-encodes for
+        // non-ASCII characters (e.g. the em-dash becomes =E2=80=93 and spaces become _).
+        // MimeUtility.decodeText decodes the RFC 2047 encoded-word back to the
+        // human-readable Unicode string so we can assert on the original content.
+        String rawSubject = MimeMessageTestUtil.getHeader(reconstituted, "Subject");
+        String subject = MimeUtility.decodeText(rawSubject);
+        String toHeader = MimeMessageTestUtil.getHeader(reconstituted, "To");
+
+        assertThat(subject).contains("Software Engineer");
+        assertThat(toHeader).contains("recruiter@example.com");
+    }
+
+    // -------------------------------------------------------------------------
+    // GoogleJsonResponseException — dailySendLimitExceeded → RateLimitException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createDraft_dailySendLimitExceededError_throwsRateLimitExceptionWithRetryAfter86400")
+    void createDraft_dailySendLimitExceededError_throwsRateLimitExceptionWithRetryAfter86400()
+            throws Exception {
+        // Arrange
+        MimeMessage mimeMessage = buildTestMimeMessage();
+        GoogleJsonResponseException gmailError =
+                buildGoogleJsonException(403, "dailySendLimitExceeded");
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.drafts()).thenReturn(drafts);
+        when(drafts.create(eq(TEST_USER_ID), any(Draft.class))).thenReturn(draftsCreate);
+        when(draftsCreate.execute()).thenThrow(gmailError);
+
+        // Act & Assert
+        assertThatThrownBy(() -> repository.createDraft(TEST_USER_ID, mimeMessage))
+                .isInstanceOf(RateLimitException.class)
+                .satisfies(ex -> {
+                    RateLimitException rle = (RateLimitException) ex;
+                    assertThat(rle.getRetryAfterSeconds()).isEqualTo(86400L);
+                });
+    }
+
+    // -------------------------------------------------------------------------
+    // GoogleJsonResponseException — invalidArgument → ValidationException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createDraft_invalidArgumentError_throwsValidationException")
+    void createDraft_invalidArgumentError_throwsValidationException() throws Exception {
+        // Arrange
+        MimeMessage mimeMessage = buildTestMimeMessage();
+        GoogleJsonResponseException gmailError =
+                buildGoogleJsonException(400, "invalidArgument");
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.drafts()).thenReturn(drafts);
+        when(drafts.create(eq(TEST_USER_ID), any(Draft.class))).thenReturn(draftsCreate);
+        when(draftsCreate.execute()).thenThrow(gmailError);
+
+        // Act & Assert
+        assertThatThrownBy(() -> repository.createDraft(TEST_USER_ID, mimeMessage))
+                .isInstanceOf(ValidationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // GeneralSecurityException from getGmailService() wraps to IOException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createDraft_generalSecurityExceptionFromServiceCreation_wrapsToIOException")
+    void createDraft_generalSecurityExceptionFromServiceCreation_wrapsToIOException()
+            throws Exception {
+        // Arrange: gmailClient.createGmailService throws GeneralSecurityException —
+        // the repository must wrap it in an IOException per the interface contract.
+        MimeMessage mimeMessage = buildTestMimeMessage();
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN))
+                .thenThrow(new GeneralSecurityException("Key store failure"));
+
+        // Act & Assert
+        assertThatThrownBy(() -> repository.createDraft(TEST_USER_ID, mimeMessage))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Security exception creating Gmail service");
+    }
+
+    // -------------------------------------------------------------------------
+    // Verify the correct Gmail API chain is invoked
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createDraft_validRequest_invokesCorrectGmailApiChain")
+    void createDraft_validRequest_invokesCorrectGmailApiChain() throws Exception {
+        // Arrange
+        MimeMessage mimeMessage = buildTestMimeMessage();
+
+        Message nestedMessage = new Message().setId(TEST_MESSAGE_ID).setThreadId(TEST_THREAD_ID);
+        Draft createdDraft = new Draft().setId(TEST_DRAFT_ID).setMessage(nestedMessage);
+        givenGmailDraftChainReturns(createdDraft);
+
+        when(gmailMessageMapper.toDraftCreationResult(any()))
+                .thenReturn(new DraftCreationResult(TEST_DRAFT_ID, TEST_MESSAGE_ID, TEST_THREAD_ID));
+
+        // Act
+        repository.createDraft(TEST_USER_ID, mimeMessage);
+
+        // Assert: verify the full API call chain.
+        verify(tokenProvider).getAccessToken();
+        verify(gmailClient).createGmailService(TEST_ACCESS_TOKEN);
+        verify(gmail).users();
+        verify(users).drafts();
+        verify(drafts).create(eq(TEST_USER_ID), any(Draft.class));
+        verify(draftsCreate).execute();
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplSendDraftTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplSendDraftTest.java
@@ -1,0 +1,271 @@
+package com.aucontraire.gmailbuddy.repository;
+
+import com.aucontraire.gmailbuddy.client.GmailBatchClient;
+import com.aucontraire.gmailbuddy.client.GmailClient;
+import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
+import com.aucontraire.gmailbuddy.exception.RateLimitException;
+import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
+import com.aucontraire.gmailbuddy.service.TokenProvider;
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.gmail.Gmail;
+import com.google.api.services.gmail.model.Draft;
+import com.google.api.services.gmail.model.Message;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link GmailRepositoryImpl#sendDraft(String, String)}.
+ *
+ * <p>Exercises the Gmail API mock chain:
+ * {@code Gmail → Users → Drafts → Send → execute()}.
+ * Verifies success mapping via {@link GmailMessageMapper}, plus the full
+ * error-mapping suite for {@link GoogleJsonResponseException}.</p>
+ *
+ * <p>Each test follows Arrange-Act-Assert with clearly separated sections per
+ * Constitution §VIII.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GmailRepositoryImpl — sendDraft")
+class GmailRepositoryImplSendDraftTest {
+
+    // -------------------------------------------------------------------------
+    // Standard test constants
+    // -------------------------------------------------------------------------
+
+    private static final String TEST_USER_ID      = "me";
+    private static final String TEST_ACCESS_TOKEN = "test-access-token-xyz";
+    private static final String TEST_DRAFT_ID     = "r-9876543210";
+    private static final String TEST_MESSAGE_ID   = "19a2b3c4d5e6f7g8";
+    private static final String TEST_THREAD_ID    = "thread-19a2b3c4d5e6f7g8";
+
+    // -------------------------------------------------------------------------
+    // Mocks for the full Gmail service dependency chain
+    // -------------------------------------------------------------------------
+
+    @Mock private GmailClient gmailClient;
+    @Mock private GmailBatchClient gmailBatchClient;
+    @Mock private TokenProvider tokenProvider;
+    @Mock private GmailBuddyProperties properties;
+    @Mock private GmailMessageMapper gmailMessageMapper;
+
+    // Gmail API call chain: Gmail → Users → Drafts → Send
+    @Mock private Gmail gmail;
+    @Mock private Gmail.Users users;
+    @Mock private Gmail.Users.Drafts drafts;
+    @Mock private Gmail.Users.Drafts.Send draftsSend;
+
+    private GmailRepositoryImpl repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new GmailRepositoryImpl(
+                gmailClient, gmailBatchClient, tokenProvider, properties, gmailMessageMapper);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: set up the standard Gmail drafts.send mock chain
+    // -------------------------------------------------------------------------
+
+    private void givenGmailDraftSendChainReturns(Message sentMessage) throws Exception {
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.drafts()).thenReturn(drafts);
+        when(drafts.send(eq(TEST_USER_ID), any(Draft.class))).thenReturn(draftsSend);
+        when(draftsSend.execute()).thenReturn(sentMessage);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: build a GoogleJsonResponseException with a specific reason code
+    // -------------------------------------------------------------------------
+
+    private GoogleJsonResponseException buildGoogleJsonException(int statusCode, String reason) {
+        GoogleJsonError error = new GoogleJsonError();
+        error.setCode(statusCode);
+        error.setMessage("Gmail API error: " + reason);
+
+        GoogleJsonError.ErrorInfo errorInfo = new GoogleJsonError.ErrorInfo();
+        errorInfo.setReason(reason);
+        error.setErrors(List.of(errorInfo));
+
+        GoogleJsonResponseException exception = mock(GoogleJsonResponseException.class);
+        when(exception.getDetails()).thenReturn(error);
+        when(exception.getMessage()).thenReturn("Gmail API error: " + reason);
+        when(exception.getStatusCode()).thenReturn(statusCode);
+        return exception;
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path — success returns SentMessageResult with correct ids
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendDraft_validDraftId_returnsSentMessageResultWithCorrectIds")
+    void sendDraft_validDraftId_returnsSentMessageResultWithCorrectIds() throws Exception {
+        // Arrange
+        Message sentMessage = new Message().setId(TEST_MESSAGE_ID).setThreadId(TEST_THREAD_ID);
+        givenGmailDraftSendChainReturns(sentMessage);
+
+        SentMessageResult expectedResult = new SentMessageResult(TEST_MESSAGE_ID, TEST_THREAD_ID);
+        when(gmailMessageMapper.toSentMessageResult(sentMessage)).thenReturn(expectedResult);
+
+        // Act
+        SentMessageResult result = repository.sendDraft(TEST_USER_ID, TEST_DRAFT_ID);
+
+        // Assert
+        assertThat(result).isNotNull();
+        assertThat(result.messageId()).isEqualTo(TEST_MESSAGE_ID);
+        assertThat(result.threadId()).isEqualTo(TEST_THREAD_ID);
+        verify(gmailMessageMapper).toSentMessageResult(sentMessage);
+    }
+
+    // -------------------------------------------------------------------------
+    // Verify the correct 3-call Gmail API chain is invoked
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendDraft_validDraftId_invokesCorrectThreeCallGmailApiChain")
+    void sendDraft_validDraftId_invokesCorrectThreeCallGmailApiChain() throws Exception {
+        // Arrange
+        Message sentMessage = new Message().setId(TEST_MESSAGE_ID).setThreadId(TEST_THREAD_ID);
+        givenGmailDraftSendChainReturns(sentMessage);
+
+        when(gmailMessageMapper.toSentMessageResult(any()))
+                .thenReturn(new SentMessageResult(TEST_MESSAGE_ID, TEST_THREAD_ID));
+
+        // Act
+        repository.sendDraft(TEST_USER_ID, TEST_DRAFT_ID);
+
+        // Assert: verify the full 3-call chain — gmail.users().drafts().send(...).execute()
+        verify(tokenProvider).getAccessToken();
+        verify(gmailClient).createGmailService(TEST_ACCESS_TOKEN);
+        verify(gmail).users();
+        verify(users).drafts();
+        verify(drafts).send(eq(TEST_USER_ID), any(Draft.class));
+        verify(draftsSend).execute();
+    }
+
+    // -------------------------------------------------------------------------
+    // Verify the Draft submitted to drafts.send contains only the draftId
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendDraft_validDraftId_submitsDraftPayloadContainingOnlyDraftId")
+    void sendDraft_validDraftId_submitsDraftPayloadContainingOnlyDraftId() throws Exception {
+        // Arrange: capture the Draft argument to verify it contains only the id.
+        Message sentMessage = new Message().setId(TEST_MESSAGE_ID).setThreadId(TEST_THREAD_ID);
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.drafts()).thenReturn(drafts);
+
+        ArgumentCaptor<Draft> draftCaptor = ArgumentCaptor.forClass(Draft.class);
+        when(drafts.send(eq(TEST_USER_ID), draftCaptor.capture())).thenReturn(draftsSend);
+        when(draftsSend.execute()).thenReturn(sentMessage);
+        when(gmailMessageMapper.toSentMessageResult(sentMessage))
+                .thenReturn(new SentMessageResult(TEST_MESSAGE_ID, TEST_THREAD_ID));
+
+        // Act
+        repository.sendDraft(TEST_USER_ID, TEST_DRAFT_ID);
+
+        // Assert: per the Javadoc, only the id field is set; Gmail resolves content
+        // from the draft store.
+        Draft captured = draftCaptor.getValue();
+        assertThat(captured.getId()).isEqualTo(TEST_DRAFT_ID);
+        // The message field must be null — only the draft id is needed.
+        assertThat(captured.getMessage()).isNull();
+    }
+
+    // -------------------------------------------------------------------------
+    // GoogleJsonResponseException 403 dailySendLimitExceeded → RateLimitException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendDraft_dailySendLimitExceededError_throwsRateLimitExceptionWithRetryAfter86400")
+    void sendDraft_dailySendLimitExceededError_throwsRateLimitExceptionWithRetryAfter86400()
+            throws Exception {
+        // Arrange
+        GoogleJsonResponseException gmailError =
+                buildGoogleJsonException(403, "dailySendLimitExceeded");
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.drafts()).thenReturn(drafts);
+        when(drafts.send(eq(TEST_USER_ID), any(Draft.class))).thenReturn(draftsSend);
+        when(draftsSend.execute()).thenThrow(gmailError);
+
+        // Act & Assert
+        assertThatThrownBy(() -> repository.sendDraft(TEST_USER_ID, TEST_DRAFT_ID))
+                .isInstanceOf(RateLimitException.class)
+                .satisfies(ex -> {
+                    RateLimitException rle = (RateLimitException) ex;
+                    assertThat(rle.getRetryAfterSeconds()).isEqualTo(86400L);
+                });
+    }
+
+    // -------------------------------------------------------------------------
+    // GoogleJsonResponseException 404 → ResourceNotFoundException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendDraft_draftNotFound_throwsResourceNotFoundException")
+    void sendDraft_draftNotFound_throwsResourceNotFoundException() throws Exception {
+        // Arrange: 404 means the draft was already sent, discarded, or the id is invalid.
+        GoogleJsonResponseException gmailError = mock(GoogleJsonResponseException.class);
+        when(gmailError.getStatusCode()).thenReturn(404);
+        // 404 mapping does not examine the reason field — status code alone is sufficient.
+        when(gmailError.getMessage()).thenReturn("Draft not found");
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.drafts()).thenReturn(drafts);
+        when(drafts.send(eq(TEST_USER_ID), any(Draft.class))).thenReturn(draftsSend);
+        when(draftsSend.execute()).thenThrow(gmailError);
+
+        // Act & Assert
+        assertThatThrownBy(() -> repository.sendDraft(TEST_USER_ID, TEST_DRAFT_ID))
+                .isInstanceOf(ResourceNotFoundException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // GeneralSecurityException from getGmailService() wraps to IOException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendDraft_generalSecurityExceptionFromServiceCreation_wrapsToIOException")
+    void sendDraft_generalSecurityExceptionFromServiceCreation_wrapsToIOException()
+            throws Exception {
+        // Arrange: gmailClient.createGmailService throws GeneralSecurityException.
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN))
+                .thenThrow(new GeneralSecurityException("Key store failure"));
+
+        // Act & Assert
+        assertThatThrownBy(() -> repository.sendDraft(TEST_USER_ID, TEST_DRAFT_ID))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Security exception creating Gmail service");
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplSendMessageTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplSendMessageTest.java
@@ -1,0 +1,358 @@
+package com.aucontraire.gmailbuddy.repository;
+
+import com.aucontraire.gmailbuddy.client.GmailBatchClient;
+import com.aucontraire.gmailbuddy.client.GmailClient;
+import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
+import com.aucontraire.gmailbuddy.exception.AuthorizationException;
+import com.aucontraire.gmailbuddy.exception.RateLimitException;
+import com.aucontraire.gmailbuddy.exception.ValidationException;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
+import com.aucontraire.gmailbuddy.service.TokenProvider;
+import com.aucontraire.gmailbuddy.util.MimeMessageTestUtil;
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
+import com.google.api.services.gmail.Gmail;
+import com.google.api.services.gmail.model.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+import jakarta.mail.internet.MimeUtility;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.List;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link GmailRepositoryImpl#sendMessage(String, MimeMessage)}.
+ *
+ * <p>Exercises the full Gmail API mock chain:
+ * {@code Gmail → Users → Messages → Send → execute()}.
+ * Verifies base64url encoding of the raw payload, success mapping via
+ * {@link GmailMessageMapper}, and the full error-mapping suite for
+ * {@link GoogleJsonResponseException}.</p>
+ *
+ * <p>Each test follows Arrange-Act-Assert with clearly separated sections per
+ * Constitution §VIII.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("GmailRepositoryImpl — sendMessage")
+class GmailRepositoryImplSendMessageTest {
+
+    // -------------------------------------------------------------------------
+    // Standard test constants
+    // -------------------------------------------------------------------------
+
+    private static final String TEST_USER_ID      = "me";
+    private static final String TEST_ACCESS_TOKEN = "test-access-token-send-abc";
+    private static final String TEST_MESSAGE_ID   = "19a2b3c4d5e6f7g8";
+    private static final String TEST_THREAD_ID    = "thread-19a2b3c4d5e6f7g8";
+
+    // -------------------------------------------------------------------------
+    // Mocks for the full Gmail service dependency chain
+    // -------------------------------------------------------------------------
+
+    @Mock private GmailClient gmailClient;
+    @Mock private GmailBatchClient gmailBatchClient;
+    @Mock private TokenProvider tokenProvider;
+    @Mock private GmailBuddyProperties properties;
+    @Mock private GmailMessageMapper gmailMessageMapper;
+
+    // Gmail API call chain: Gmail → Users → Messages → Send
+    @Mock private Gmail gmail;
+    @Mock private Gmail.Users users;
+    @Mock private Gmail.Users.Messages messages;
+    @Mock private Gmail.Users.Messages.Send messagesSend;
+
+    private GmailRepositoryImpl repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new GmailRepositoryImpl(
+                gmailClient, gmailBatchClient, tokenProvider, properties, gmailMessageMapper);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: build a minimal MimeMessage for use in tests
+    // -------------------------------------------------------------------------
+
+    private MimeMessage buildTestMimeMessage() throws MessagingException {
+        Session session = Session.getInstance(new Properties());
+        MimeMessage mimeMessage = new MimeMessage(session);
+        mimeMessage.setFrom(new InternetAddress("sender@example.com"));
+        mimeMessage.addRecipient(
+                MimeMessage.RecipientType.TO,
+                new InternetAddress("recruiter@example.com"));
+        mimeMessage.setSubject("Software Engineer – Application Follow-up");
+        mimeMessage.setText("Hi there, following up on my application.");
+        mimeMessage.saveChanges();
+        return mimeMessage;
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: set up the standard Gmail messages.send mock chain
+    // -------------------------------------------------------------------------
+
+    private void givenGmailMessageSendChainReturns(Message sentMessage) throws Exception {
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.messages()).thenReturn(messages);
+        when(messages.send(eq(TEST_USER_ID), any(Message.class))).thenReturn(messagesSend);
+        when(messagesSend.execute()).thenReturn(sentMessage);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: build a GoogleJsonResponseException with a specific reason code
+    // -------------------------------------------------------------------------
+
+    private GoogleJsonResponseException buildGoogleJsonException(int statusCode, String reason) {
+        GoogleJsonError error = new GoogleJsonError();
+        error.setCode(statusCode);
+        error.setMessage("Gmail API error: " + reason);
+
+        GoogleJsonError.ErrorInfo errorInfo = new GoogleJsonError.ErrorInfo();
+        errorInfo.setReason(reason);
+        error.setErrors(List.of(errorInfo));
+
+        GoogleJsonResponseException exception = mock(GoogleJsonResponseException.class);
+        when(exception.getDetails()).thenReturn(error);
+        when(exception.getMessage()).thenReturn("Gmail API error: " + reason);
+        when(exception.getStatusCode()).thenReturn(statusCode);
+        return exception;
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path — success returns SentMessageResult with correct ids
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_validMimeMessage_returnsSentMessageResultWithCorrectIds")
+    void sendMessage_validMimeMessage_returnsSentMessageResultWithCorrectIds() throws Exception {
+        // Arrange
+        MimeMessage mimeMessage = buildTestMimeMessage();
+        Message sentMessage = new Message().setId(TEST_MESSAGE_ID).setThreadId(TEST_THREAD_ID);
+        givenGmailMessageSendChainReturns(sentMessage);
+
+        SentMessageResult expectedResult = new SentMessageResult(TEST_MESSAGE_ID, TEST_THREAD_ID);
+        when(gmailMessageMapper.toSentMessageResult(sentMessage)).thenReturn(expectedResult);
+
+        // Act
+        SentMessageResult result = repository.sendMessage(TEST_USER_ID, mimeMessage);
+
+        // Assert
+        assertThat(result).isNotNull();
+        assertThat(result.messageId()).isEqualTo(TEST_MESSAGE_ID);
+        assertThat(result.threadId()).isEqualTo(TEST_THREAD_ID);
+        verify(gmailMessageMapper).toSentMessageResult(sentMessage);
+    }
+
+    // -------------------------------------------------------------------------
+    // base64url-encoded raw payload reconstitutes via MimeMessageTestUtil
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_validMimeMessage_base64UrlEncodedPayloadReconstitutesToCorrectMimeHeaders")
+    void sendMessage_validMimeMessage_base64UrlEncodedPayloadReconstitutesToCorrectMimeHeaders()
+            throws Exception {
+        // Arrange: capture the Message argument passed to messages.send(...) so we can
+        // inspect the base64url-encoded raw payload and decode it back to a MimeMessage.
+        MimeMessage originalMimeMessage = buildTestMimeMessage();
+        Message sentMessage = new Message().setId(TEST_MESSAGE_ID).setThreadId(TEST_THREAD_ID);
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.messages()).thenReturn(messages);
+
+        ArgumentCaptor<Message> messageCaptor = ArgumentCaptor.forClass(Message.class);
+        when(messages.send(eq(TEST_USER_ID), messageCaptor.capture())).thenReturn(messagesSend);
+        when(messagesSend.execute()).thenReturn(sentMessage);
+        when(gmailMessageMapper.toSentMessageResult(sentMessage))
+                .thenReturn(new SentMessageResult(TEST_MESSAGE_ID, TEST_THREAD_ID));
+
+        // Act
+        repository.sendMessage(TEST_USER_ID, originalMimeMessage);
+
+        // Assert: decode the base64url raw payload and verify subject + recipient.
+        // MimeUtility.decodeText must be applied to handle RFC 2047 Q-encoded headers
+        // (e.g. the em-dash in the subject becomes =E2=80=93 on the wire).
+        Message captured = messageCaptor.getValue();
+        assertThat(captured.getRaw()).isNotBlank();
+
+        MimeMessage reconstituted = MimeMessageTestUtil.fromBase64Url(captured.getRaw());
+        String rawSubject = MimeMessageTestUtil.getHeader(reconstituted, "Subject");
+        String subject = MimeUtility.decodeText(rawSubject);
+        String toHeader = MimeMessageTestUtil.getHeader(reconstituted, "To");
+
+        assertThat(subject).contains("Software Engineer");
+        assertThat(toHeader).contains("recruiter@example.com");
+    }
+
+    // -------------------------------------------------------------------------
+    // Verify the correct Gmail API chain is invoked
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_validRequest_invokesCorrectGmailApiChain")
+    void sendMessage_validRequest_invokesCorrectGmailApiChain() throws Exception {
+        // Arrange
+        MimeMessage mimeMessage = buildTestMimeMessage();
+        Message sentMessage = new Message().setId(TEST_MESSAGE_ID).setThreadId(TEST_THREAD_ID);
+        givenGmailMessageSendChainReturns(sentMessage);
+
+        when(gmailMessageMapper.toSentMessageResult(any()))
+                .thenReturn(new SentMessageResult(TEST_MESSAGE_ID, TEST_THREAD_ID));
+
+        // Act
+        repository.sendMessage(TEST_USER_ID, mimeMessage);
+
+        // Assert: verify the full API call chain.
+        verify(tokenProvider).getAccessToken();
+        verify(gmailClient).createGmailService(TEST_ACCESS_TOKEN);
+        verify(gmail).users();
+        verify(users).messages();
+        verify(messages).send(eq(TEST_USER_ID), any(Message.class));
+        verify(messagesSend).execute();
+    }
+
+    // -------------------------------------------------------------------------
+    // GoogleJsonResponseException — invalidArgument → ValidationException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_invalidArgumentError_throwsValidationException")
+    void sendMessage_invalidArgumentError_throwsValidationException() throws Exception {
+        // Arrange: Gmail rejects the recipient with 400 invalidArgument.
+        MimeMessage mimeMessage = buildTestMimeMessage();
+        GoogleJsonResponseException gmailError =
+                buildGoogleJsonException(400, "invalidArgument");
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.messages()).thenReturn(messages);
+        when(messages.send(eq(TEST_USER_ID), any(Message.class))).thenReturn(messagesSend);
+        when(messagesSend.execute()).thenThrow(gmailError);
+
+        // Act & Assert
+        assertThatThrownBy(() -> repository.sendMessage(TEST_USER_ID, mimeMessage))
+                .isInstanceOf(ValidationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // GoogleJsonResponseException — dailySendLimitExceeded → RateLimitException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_dailySendLimitExceededError_throwsRateLimitExceptionWithRetryAfter86400")
+    void sendMessage_dailySendLimitExceededError_throwsRateLimitExceptionWithRetryAfter86400()
+            throws Exception {
+        // Arrange
+        MimeMessage mimeMessage = buildTestMimeMessage();
+        GoogleJsonResponseException gmailError =
+                buildGoogleJsonException(403, "dailySendLimitExceeded");
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.messages()).thenReturn(messages);
+        when(messages.send(eq(TEST_USER_ID), any(Message.class))).thenReturn(messagesSend);
+        when(messagesSend.execute()).thenThrow(gmailError);
+
+        // Act & Assert
+        assertThatThrownBy(() -> repository.sendMessage(TEST_USER_ID, mimeMessage))
+                .isInstanceOf(RateLimitException.class)
+                .satisfies(ex -> {
+                    RateLimitException rle = (RateLimitException) ex;
+                    assertThat(rle.getRetryAfterSeconds()).isEqualTo(86400L);
+                });
+    }
+
+    // -------------------------------------------------------------------------
+    // GoogleJsonResponseException — insufficientPermissions → AuthorizationException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_insufficientPermissionsError_throwsAuthorizationException")
+    void sendMessage_insufficientPermissionsError_throwsAuthorizationException() throws Exception {
+        // Arrange
+        MimeMessage mimeMessage = buildTestMimeMessage();
+        GoogleJsonResponseException gmailError =
+                buildGoogleJsonException(403, "insufficientPermissions");
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.messages()).thenReturn(messages);
+        when(messages.send(eq(TEST_USER_ID), any(Message.class))).thenReturn(messagesSend);
+        when(messagesSend.execute()).thenThrow(gmailError);
+
+        // Act & Assert
+        assertThatThrownBy(() -> repository.sendMessage(TEST_USER_ID, mimeMessage))
+                .isInstanceOf(AuthorizationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // GoogleJsonResponseException — messageTooLarge → ValidationException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_messageTooLargeError_throwsValidationException")
+    void sendMessage_messageTooLargeError_throwsValidationException() throws Exception {
+        // Arrange
+        MimeMessage mimeMessage = buildTestMimeMessage();
+        GoogleJsonResponseException gmailError =
+                buildGoogleJsonException(413, "messageTooLarge");
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.messages()).thenReturn(messages);
+        when(messages.send(eq(TEST_USER_ID), any(Message.class))).thenReturn(messagesSend);
+        when(messagesSend.execute()).thenThrow(gmailError);
+
+        // Act & Assert
+        assertThatThrownBy(() -> repository.sendMessage(TEST_USER_ID, mimeMessage))
+                .isInstanceOf(ValidationException.class);
+    }
+
+    // -------------------------------------------------------------------------
+    // GeneralSecurityException from getGmailService() wraps to IOException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_generalSecurityExceptionFromServiceCreation_wrapsToIOException")
+    void sendMessage_generalSecurityExceptionFromServiceCreation_wrapsToIOException()
+            throws Exception {
+        // Arrange: gmailClient.createGmailService throws GeneralSecurityException —
+        // the repository must wrap it in an IOException per the interface contract.
+        MimeMessage mimeMessage = buildTestMimeMessage();
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN))
+                .thenThrow(new GeneralSecurityException("Key store failure"));
+
+        // Act & Assert
+        assertThatThrownBy(() -> repository.sendMessage(TEST_USER_ID, mimeMessage))
+                .isInstanceOf(IOException.class)
+                .hasMessageContaining("Security exception creating Gmail service");
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplTest.java
@@ -4,6 +4,7 @@ import com.aucontraire.gmailbuddy.client.GmailClient;
 import com.aucontraire.gmailbuddy.client.GmailBatchClient;
 import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
 import com.aucontraire.gmailbuddy.exception.AuthenticationException;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.service.TokenProvider;
 import com.aucontraire.gmailbuddy.service.BulkOperationResult;
 import com.google.api.services.gmail.Gmail;
@@ -50,7 +51,10 @@ class GmailRepositoryImplTest {
 
     @Mock
     private GmailBuddyProperties properties;
-    
+
+    @Mock
+    private GmailMessageMapper gmailMessageMapper;
+
     @Mock
     private Gmail gmail;
     
@@ -78,7 +82,7 @@ class GmailRepositoryImplTest {
     
     @BeforeEach
     void setUp() {
-        repository = new GmailRepositoryImpl(gmailClient, gmailBatchClient, tokenProvider, properties);
+        repository = new GmailRepositoryImpl(gmailClient, gmailBatchClient, tokenProvider, properties, gmailMessageMapper);
     }
     
     @Test

--- a/src/test/java/com/aucontraire/gmailbuddy/security/Phase2ErrorScenariosTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/security/Phase2ErrorScenariosTest.java
@@ -410,7 +410,7 @@ class Phase2ErrorScenariosTest {
             // Mock token reference service
             TokenReference mockTokenReference = mock(TokenReference.class);
             when(mockTokenReference.getReferenceId()).thenReturn("ref-123");
-            when(tokenReferenceService.createTokenReference(VALID_TOKEN, "test@example.com")).thenReturn(mockTokenReference);
+            when(tokenReferenceService.createTokenReference(eq(VALID_TOKEN), eq("test@example.com"), anyString())).thenReturn(mockTokenReference);
 
             // Mock SecurityContext to throw exception when setAuthentication is called
             doThrow(new RuntimeException("SecurityContext corrupted")).when(securityContext).setAuthentication(any());

--- a/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceCreateDraftTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceCreateDraftTest.java
@@ -1,0 +1,234 @@
+package com.aucontraire.gmailbuddy.service;
+
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+import com.aucontraire.gmailbuddy.exception.GmailApiException;
+import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.mapper.FilterCriteriaMapper;
+import com.aucontraire.gmailbuddy.repository.GmailRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure Mockito unit tests for {@link GmailService#createDraft(String, SendMessageDTO)}.
+ *
+ * <p>Verifies the service orchestration: DTO → MimeMessage (via {@link MimeMessageBuilder})
+ * → repository call → return {@link DraftCreationResult}. No Spring context is loaded;
+ * all dependencies are hand-mocked.</p>
+ *
+ * <p>Each test follows Arrange-Act-Assert per Constitution §VIII.</p>
+ */
+@DisplayName("GmailService — createDraft")
+class GmailServiceCreateDraftTest {
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    private static final String USER_ID        = "me";
+    private static final String TEST_DRAFT_ID  = "r-9876543210";
+    private static final String TEST_MSG_ID    = "19a2b3c4d5e6f7g8";
+    private static final String TEST_THREAD_ID = "19a2b3c4d5e6f7g8";
+
+    // -------------------------------------------------------------------------
+    // System under test + all collaborators (hand-mocked)
+    // -------------------------------------------------------------------------
+
+    private GmailRepository gmailRepository;
+    private GmailQueryBuilder gmailQueryBuilder;
+    private FilterCriteriaMapper filterCriteriaMapper;
+    private MimeMessageBuilder mimeMessageBuilder;
+    private GmailService gmailService;
+
+    @BeforeEach
+    void setUp() {
+        gmailRepository      = mock(GmailRepository.class);
+        gmailQueryBuilder    = mock(GmailQueryBuilder.class);
+        filterCriteriaMapper = mock(FilterCriteriaMapper.class);
+        mimeMessageBuilder   = mock(MimeMessageBuilder.class);
+        gmailService = new GmailService(
+                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: create a no-op MimeMessage for stubbing
+    // -------------------------------------------------------------------------
+
+    private MimeMessage emptyMimeMessage() {
+        return new MimeMessage(Session.getInstance(new Properties()));
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createDraft_validDto_callsMimeMessageBuilderExactlyOnce")
+    void createDraft_validDto_callsMimeMessageBuilderExactlyOnce()
+            throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        MimeMessage mimeMessage = emptyMimeMessage();
+        DraftCreationResult expected =
+                new DraftCreationResult(TEST_DRAFT_ID, TEST_MSG_ID, TEST_THREAD_ID);
+
+        when(mimeMessageBuilder.build(dto)).thenReturn(mimeMessage);
+        when(gmailRepository.createDraft(USER_ID, mimeMessage)).thenReturn(expected);
+
+        // Act
+        gmailService.createDraft(USER_ID, dto);
+
+        // Assert: MimeMessageBuilder.build is called exactly once with the dto.
+        verify(mimeMessageBuilder).build(dto);
+    }
+
+    @Test
+    @DisplayName("createDraft_validDto_callsRepositoryCreateDraftExactlyOnce")
+    void createDraft_validDto_callsRepositoryCreateDraftExactlyOnce()
+            throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        MimeMessage mimeMessage = emptyMimeMessage();
+        DraftCreationResult expected =
+                new DraftCreationResult(TEST_DRAFT_ID, TEST_MSG_ID, TEST_THREAD_ID);
+
+        when(mimeMessageBuilder.build(dto)).thenReturn(mimeMessage);
+        when(gmailRepository.createDraft(USER_ID, mimeMessage)).thenReturn(expected);
+
+        // Act
+        gmailService.createDraft(USER_ID, dto);
+
+        // Assert: repository.createDraft is called exactly once with the userId
+        // and the MimeMessage produced by the builder.
+        verify(gmailRepository).createDraft(eq(USER_ID), eq(mimeMessage));
+    }
+
+    @Test
+    @DisplayName("createDraft_validDto_returnsExactResultFromRepository")
+    void createDraft_validDto_returnsExactResultFromRepository() throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        MimeMessage mimeMessage = emptyMimeMessage();
+        DraftCreationResult expected =
+                new DraftCreationResult(TEST_DRAFT_ID, TEST_MSG_ID, TEST_THREAD_ID);
+
+        when(mimeMessageBuilder.build(dto)).thenReturn(mimeMessage);
+        when(gmailRepository.createDraft(USER_ID, mimeMessage)).thenReturn(expected);
+
+        // Act
+        DraftCreationResult actual = gmailService.createDraft(USER_ID, dto);
+
+        // Assert
+        assertThat(actual).isSameAs(expected);
+        assertThat(actual.draftId()).isEqualTo(TEST_DRAFT_ID);
+        assertThat(actual.messageId()).isEqualTo(TEST_MSG_ID);
+        assertThat(actual.threadId()).isEqualTo(TEST_THREAD_ID);
+    }
+
+    // -------------------------------------------------------------------------
+    // MessagingException from MimeMessageBuilder wraps to GmailApiException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createDraft_mimeMessageBuilderThrowsMessagingException_wrapsToGmailApiException")
+    void createDraft_mimeMessageBuilderThrowsMessagingException_wrapsToGmailApiException()
+            throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        MessagingException cause = new MessagingException("JavaMail header set failure");
+
+        when(mimeMessageBuilder.build(dto)).thenThrow(cause);
+
+        // Act & Assert
+        assertThatThrownBy(() -> gmailService.createDraft(USER_ID, dto))
+                .isInstanceOf(GmailApiException.class)
+                .hasMessageContaining("Failed to construct email message for draft")
+                .hasCause(cause);
+
+        // Verify repository is NOT called when builder fails.
+        verify(gmailRepository, never()).createDraft(any(), any());
+    }
+
+    @Test
+    @DisplayName("createDraft_mimeMessageBuilderThrowsUnsupportedEncodingException_wrapsToGmailApiException")
+    void createDraft_mimeMessageBuilderThrowsUnsupportedEncodingException_wrapsToGmailApiException()
+            throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        UnsupportedEncodingException cause = new UnsupportedEncodingException("UTF-8 not supported");
+
+        when(mimeMessageBuilder.build(dto)).thenThrow(cause);
+
+        // Act & Assert
+        assertThatThrownBy(() -> gmailService.createDraft(USER_ID, dto))
+                .isInstanceOf(GmailApiException.class)
+                .hasMessageContaining("Failed to construct email message for draft")
+                .hasCause(cause);
+
+        verify(gmailRepository, never()).createDraft(any(), any());
+    }
+
+    // -------------------------------------------------------------------------
+    // IOException from repository propagates as GmailApiException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createDraft_repositoryThrowsIOException_wrapsToGmailApiException")
+    void createDraft_repositoryThrowsIOException_wrapsToGmailApiException() throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        MimeMessage mimeMessage = emptyMimeMessage();
+        IOException cause = new IOException("Network timeout reaching Gmail API");
+
+        when(mimeMessageBuilder.build(dto)).thenReturn(mimeMessage);
+        when(gmailRepository.createDraft(USER_ID, mimeMessage)).thenThrow(cause);
+
+        // Act & Assert
+        assertThatThrownBy(() -> gmailService.createDraft(USER_ID, dto))
+                .isInstanceOf(GmailApiException.class)
+                .hasMessageContaining("Failed to create draft for user: " + USER_ID)
+                .hasCause(cause);
+    }
+
+    // -------------------------------------------------------------------------
+    // Multi-recipient DTO — still delegates to builder and repository
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("createDraft_multiRecipientDto_delegatesToBuilderAndRepositoryCorrectly")
+    void createDraft_multiRecipientDto_delegatesToBuilderAndRepositoryCorrectly()
+            throws Exception {
+        // Arrange: multi-recipient DTO to confirm service is not hard-coding recipient handling.
+        SendMessageDTO dto = SendMessageRequestFixtures.validMultiRecipientWithCcAndBcc();
+        MimeMessage mimeMessage = emptyMimeMessage();
+        DraftCreationResult expected =
+                new DraftCreationResult(TEST_DRAFT_ID, TEST_MSG_ID, TEST_THREAD_ID);
+
+        when(mimeMessageBuilder.build(dto)).thenReturn(mimeMessage);
+        when(gmailRepository.createDraft(USER_ID, mimeMessage)).thenReturn(expected);
+
+        // Act
+        DraftCreationResult actual = gmailService.createDraft(USER_ID, dto);
+
+        // Assert
+        verify(mimeMessageBuilder).build(dto);
+        verify(gmailRepository).createDraft(USER_ID, mimeMessage);
+        assertThat(actual).isSameAs(expected);
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceSendDraftTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceSendDraftTest.java
@@ -1,0 +1,132 @@
+package com.aucontraire.gmailbuddy.service;
+
+import com.aucontraire.gmailbuddy.exception.GmailApiException;
+import com.aucontraire.gmailbuddy.mapper.FilterCriteriaMapper;
+import com.aucontraire.gmailbuddy.repository.GmailRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure Mockito unit tests for {@link GmailService#sendDraft(String, String)}.
+ *
+ * <p>Verifies the thin pass-through orchestration: service delegates directly to
+ * {@link GmailRepository#sendDraft(String, String)} without constructing a
+ * MimeMessage (the draft content already lives on Gmail's side). No Spring
+ * context is loaded; all dependencies are hand-mocked.</p>
+ *
+ * <p>Each test follows Arrange-Act-Assert per Constitution §VIII.</p>
+ */
+@DisplayName("GmailService — sendDraft")
+class GmailServiceSendDraftTest {
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    private static final String USER_ID        = "me";
+    private static final String TEST_DRAFT_ID  = "r-9876543210";
+    private static final String TEST_MSG_ID    = "19a2b3c4d5e6f7g8";
+    private static final String TEST_THREAD_ID = "thread-19a2b3c4d5e6f7g8";
+
+    // -------------------------------------------------------------------------
+    // System under test + all collaborators (hand-mocked)
+    // -------------------------------------------------------------------------
+
+    private GmailRepository gmailRepository;
+    private GmailQueryBuilder gmailQueryBuilder;
+    private FilterCriteriaMapper filterCriteriaMapper;
+    private MimeMessageBuilder mimeMessageBuilder;
+    private GmailService gmailService;
+
+    @BeforeEach
+    void setUp() {
+        gmailRepository      = mock(GmailRepository.class);
+        gmailQueryBuilder    = mock(GmailQueryBuilder.class);
+        filterCriteriaMapper = mock(FilterCriteriaMapper.class);
+        mimeMessageBuilder   = mock(MimeMessageBuilder.class);
+        gmailService = new GmailService(
+                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder);
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path — delegates correctly and returns repository result
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendDraft_validDraftId_callsRepositorySendDraftExactlyOnce")
+    void sendDraft_validDraftId_callsRepositorySendDraftExactlyOnce() throws Exception {
+        // Arrange
+        SentMessageResult expected = new SentMessageResult(TEST_MSG_ID, TEST_THREAD_ID);
+        when(gmailRepository.sendDraft(USER_ID, TEST_DRAFT_ID)).thenReturn(expected);
+
+        // Act
+        gmailService.sendDraft(USER_ID, TEST_DRAFT_ID);
+
+        // Assert: repository.sendDraft is called exactly once with the correct arguments.
+        verify(gmailRepository).sendDraft(USER_ID, TEST_DRAFT_ID);
+    }
+
+    @Test
+    @DisplayName("sendDraft_validDraftId_returnsExactResultFromRepository")
+    void sendDraft_validDraftId_returnsExactResultFromRepository() throws Exception {
+        // Arrange
+        SentMessageResult expected = new SentMessageResult(TEST_MSG_ID, TEST_THREAD_ID);
+        when(gmailRepository.sendDraft(USER_ID, TEST_DRAFT_ID)).thenReturn(expected);
+
+        // Act
+        SentMessageResult actual = gmailService.sendDraft(USER_ID, TEST_DRAFT_ID);
+
+        // Assert
+        assertThat(actual).isSameAs(expected);
+        assertThat(actual.messageId()).isEqualTo(TEST_MSG_ID);
+        assertThat(actual.threadId()).isEqualTo(TEST_THREAD_ID);
+    }
+
+    // -------------------------------------------------------------------------
+    // No MimeMessageBuilder involvement — pure thin pass-through
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendDraft_validDraftId_doesNotInvokeMimeMessageBuilder")
+    void sendDraft_validDraftId_doesNotInvokeMimeMessageBuilder() throws Exception {
+        // Arrange: sendDraft does NOT construct a MimeMessage; draft content already
+        // lives in Gmail's draft store.
+        SentMessageResult result = new SentMessageResult(TEST_MSG_ID, TEST_THREAD_ID);
+        when(gmailRepository.sendDraft(USER_ID, TEST_DRAFT_ID)).thenReturn(result);
+
+        // Act
+        gmailService.sendDraft(USER_ID, TEST_DRAFT_ID);
+
+        // Assert: MimeMessageBuilder must not be touched.
+        // Any invocation on mimeMessageBuilder would be detected by strict Mockito
+        // — this test succeeds if no call was made.
+        org.mockito.Mockito.verifyNoInteractions(mimeMessageBuilder);
+    }
+
+    // -------------------------------------------------------------------------
+    // IOException from repository propagates as GmailApiException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendDraft_repositoryThrowsIOException_wrapsToGmailApiException")
+    void sendDraft_repositoryThrowsIOException_wrapsToGmailApiException() throws Exception {
+        // Arrange
+        IOException cause = new IOException("Network timeout reaching Gmail API");
+        when(gmailRepository.sendDraft(USER_ID, TEST_DRAFT_ID)).thenThrow(cause);
+
+        // Act & Assert
+        assertThatThrownBy(() -> gmailService.sendDraft(USER_ID, TEST_DRAFT_ID))
+                .isInstanceOf(GmailApiException.class)
+                .hasMessageContaining("Failed to send draft for draftId: " + TEST_DRAFT_ID)
+                .hasCause(cause);
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceSendMessageTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceSendMessageTest.java
@@ -1,0 +1,227 @@
+package com.aucontraire.gmailbuddy.service;
+
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+import com.aucontraire.gmailbuddy.exception.GmailApiException;
+import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.mapper.FilterCriteriaMapper;
+import com.aucontraire.gmailbuddy.repository.GmailRepository;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.util.Properties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Pure Mockito unit tests for {@link GmailService#sendMessage(String, SendMessageDTO)}.
+ *
+ * <p>Mirrors {@code GmailServiceCreateDraftTest}. Verifies the service orchestration:
+ * DTO → MimeMessage (via {@link MimeMessageBuilder}) → repository call →
+ * return {@link SentMessageResult}. No Spring context is loaded; all dependencies
+ * are hand-mocked.</p>
+ *
+ * <p>Each test follows Arrange-Act-Assert per Constitution §VIII.</p>
+ */
+@DisplayName("GmailService — sendMessage")
+class GmailServiceSendMessageTest {
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    private static final String USER_ID        = "me";
+    private static final String TEST_MSG_ID    = "19a2b3c4d5e6f7g8";
+    private static final String TEST_THREAD_ID = "thread-19a2b3c4d5e6f7g8";
+
+    // -------------------------------------------------------------------------
+    // System under test + all collaborators (hand-mocked)
+    // -------------------------------------------------------------------------
+
+    private GmailRepository gmailRepository;
+    private GmailQueryBuilder gmailQueryBuilder;
+    private FilterCriteriaMapper filterCriteriaMapper;
+    private MimeMessageBuilder mimeMessageBuilder;
+    private GmailService gmailService;
+
+    @BeforeEach
+    void setUp() {
+        gmailRepository      = mock(GmailRepository.class);
+        gmailQueryBuilder    = mock(GmailQueryBuilder.class);
+        filterCriteriaMapper = mock(FilterCriteriaMapper.class);
+        mimeMessageBuilder   = mock(MimeMessageBuilder.class);
+        gmailService = new GmailService(
+                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder);
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper: create a no-op MimeMessage for stubbing
+    // -------------------------------------------------------------------------
+
+    private MimeMessage emptyMimeMessage() {
+        return new MimeMessage(Session.getInstance(new Properties()));
+    }
+
+    // -------------------------------------------------------------------------
+    // Happy path — delegates correctly and returns repository result
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_validDto_callsMimeMessageBuilderExactlyOnce")
+    void sendMessage_validDto_callsMimeMessageBuilderExactlyOnce() throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        MimeMessage mimeMessage = emptyMimeMessage();
+        SentMessageResult expected = new SentMessageResult(TEST_MSG_ID, TEST_THREAD_ID);
+
+        when(mimeMessageBuilder.build(dto)).thenReturn(mimeMessage);
+        when(gmailRepository.sendMessage(USER_ID, mimeMessage)).thenReturn(expected);
+
+        // Act
+        gmailService.sendMessage(USER_ID, dto);
+
+        // Assert: MimeMessageBuilder.build is called exactly once with the dto.
+        verify(mimeMessageBuilder).build(dto);
+    }
+
+    @Test
+    @DisplayName("sendMessage_validDto_callsRepositorySendMessageExactlyOnce")
+    void sendMessage_validDto_callsRepositorySendMessageExactlyOnce() throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        MimeMessage mimeMessage = emptyMimeMessage();
+        SentMessageResult expected = new SentMessageResult(TEST_MSG_ID, TEST_THREAD_ID);
+
+        when(mimeMessageBuilder.build(dto)).thenReturn(mimeMessage);
+        when(gmailRepository.sendMessage(USER_ID, mimeMessage)).thenReturn(expected);
+
+        // Act
+        gmailService.sendMessage(USER_ID, dto);
+
+        // Assert: repository.sendMessage is called exactly once with the userId
+        // and the MimeMessage produced by the builder.
+        verify(gmailRepository).sendMessage(eq(USER_ID), eq(mimeMessage));
+    }
+
+    @Test
+    @DisplayName("sendMessage_validDto_returnsExactResultFromRepository")
+    void sendMessage_validDto_returnsExactResultFromRepository() throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        MimeMessage mimeMessage = emptyMimeMessage();
+        SentMessageResult expected = new SentMessageResult(TEST_MSG_ID, TEST_THREAD_ID);
+
+        when(mimeMessageBuilder.build(dto)).thenReturn(mimeMessage);
+        when(gmailRepository.sendMessage(USER_ID, mimeMessage)).thenReturn(expected);
+
+        // Act
+        SentMessageResult actual = gmailService.sendMessage(USER_ID, dto);
+
+        // Assert
+        assertThat(actual).isSameAs(expected);
+        assertThat(actual.messageId()).isEqualTo(TEST_MSG_ID);
+        assertThat(actual.threadId()).isEqualTo(TEST_THREAD_ID);
+    }
+
+    // -------------------------------------------------------------------------
+    // MessagingException from MimeMessageBuilder wraps to GmailApiException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_mimeMessageBuilderThrowsMessagingException_wrapsToGmailApiException")
+    void sendMessage_mimeMessageBuilderThrowsMessagingException_wrapsToGmailApiException()
+            throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        MessagingException cause = new MessagingException("JavaMail header set failure");
+
+        when(mimeMessageBuilder.build(dto)).thenThrow(cause);
+
+        // Act & Assert
+        assertThatThrownBy(() -> gmailService.sendMessage(USER_ID, dto))
+                .isInstanceOf(GmailApiException.class)
+                .hasMessageContaining("Failed to construct email message for send")
+                .hasCause(cause);
+
+        // Verify repository is NOT called when builder fails.
+        verify(gmailRepository, never()).sendMessage(any(), any());
+    }
+
+    @Test
+    @DisplayName("sendMessage_mimeMessageBuilderThrowsUnsupportedEncodingException_wrapsToGmailApiException")
+    void sendMessage_mimeMessageBuilderThrowsUnsupportedEncodingException_wrapsToGmailApiException()
+            throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        UnsupportedEncodingException cause = new UnsupportedEncodingException("UTF-8 not supported");
+
+        when(mimeMessageBuilder.build(dto)).thenThrow(cause);
+
+        // Act & Assert
+        assertThatThrownBy(() -> gmailService.sendMessage(USER_ID, dto))
+                .isInstanceOf(GmailApiException.class)
+                .hasMessageContaining("Failed to construct email message for send")
+                .hasCause(cause);
+
+        verify(gmailRepository, never()).sendMessage(any(), any());
+    }
+
+    // -------------------------------------------------------------------------
+    // IOException from repository propagates as GmailApiException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_repositoryThrowsIOException_wrapsToGmailApiException")
+    void sendMessage_repositoryThrowsIOException_wrapsToGmailApiException() throws Exception {
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        MimeMessage mimeMessage = emptyMimeMessage();
+        IOException cause = new IOException("Network timeout reaching Gmail API");
+
+        when(mimeMessageBuilder.build(dto)).thenReturn(mimeMessage);
+        when(gmailRepository.sendMessage(USER_ID, mimeMessage)).thenThrow(cause);
+
+        // Act & Assert
+        assertThatThrownBy(() -> gmailService.sendMessage(USER_ID, dto))
+                .isInstanceOf(GmailApiException.class)
+                .hasMessageContaining("Failed to send message for user: " + USER_ID)
+                .hasCause(cause);
+    }
+
+    // -------------------------------------------------------------------------
+    // Multi-recipient DTO — still delegates to builder and repository
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendMessage_multiRecipientDto_delegatesToBuilderAndRepositoryCorrectly")
+    void sendMessage_multiRecipientDto_delegatesToBuilderAndRepositoryCorrectly()
+            throws Exception {
+        // Arrange: multi-recipient DTO to confirm service is not hard-coding recipient handling.
+        SendMessageDTO dto = SendMessageRequestFixtures.validMultiRecipientWithCcAndBcc();
+        MimeMessage mimeMessage = emptyMimeMessage();
+        SentMessageResult expected = new SentMessageResult(TEST_MSG_ID, TEST_THREAD_ID);
+
+        when(mimeMessageBuilder.build(dto)).thenReturn(mimeMessage);
+        when(gmailRepository.sendMessage(USER_ID, mimeMessage)).thenReturn(expected);
+
+        // Act
+        SentMessageResult actual = gmailService.sendMessage(USER_ID, dto);
+
+        // Assert
+        verify(mimeMessageBuilder).build(dto);
+        verify(gmailRepository).sendMessage(USER_ID, mimeMessage);
+        assertThat(actual).isSameAs(expected);
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceTest.java
@@ -31,6 +31,7 @@ class GmailServiceTest {
     private GmailRepository gmailRepository;
     private GmailQueryBuilder gmailQueryBuilder;
     private FilterCriteriaMapper filterCriteriaMapper;
+    private MimeMessageBuilder mimeMessageBuilder;
     private GmailService gmailService;
 
     @BeforeEach
@@ -38,7 +39,8 @@ class GmailServiceTest {
         gmailRepository = mock(GmailRepository.class);
         gmailQueryBuilder = mock(GmailQueryBuilder.class);
         filterCriteriaMapper = mock(FilterCriteriaMapper.class);
-        gmailService = new GmailService(gmailRepository, gmailQueryBuilder, filterCriteriaMapper);
+        mimeMessageBuilder = mock(MimeMessageBuilder.class);
+        gmailService = new GmailService(gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder);
     }
 
     @Test

--- a/src/test/java/com/aucontraire/gmailbuddy/service/MimeMessageBuilderTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/service/MimeMessageBuilderTest.java
@@ -1,0 +1,344 @@
+package com.aucontraire.gmailbuddy.service;
+
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.util.MimeMessageTestUtil;
+import jakarta.mail.Address;
+import jakarta.mail.Message.RecipientType;
+import jakarta.mail.MessagingException;
+import jakarta.mail.internet.MimeMessage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.UnsupportedEncodingException;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link MimeMessageBuilder#build(SendMessageDTO)}.
+ *
+ * <p>The builder is a pure conversion utility with no external dependencies —
+ * no Spring context is required. Each test constructs the builder directly,
+ * invokes {@code build()}, and asserts on the resulting {@link MimeMessage}
+ * using the JavaMail API and {@link MimeMessageTestUtil#getHeader}.</p>
+ *
+ * <p>{@link SendMessageRequestFixtures} is used wherever a pre-built DTO
+ * matches the scenario; bespoke DTOs are constructed inline only when the
+ * fixture doesn't cover the exact case.</p>
+ *
+ * <p>Test naming follows the project convention:
+ * {@code methodName_stateUnderTest_expectedBehavior}.</p>
+ */
+class MimeMessageBuilderTest {
+
+    private MimeMessageBuilder builder;
+
+    @BeforeEach
+    void setUp() {
+        builder = new MimeMessageBuilder();
+    }
+
+    // -------------------------------------------------------------------------
+    // build — single primary recipient
+    // -------------------------------------------------------------------------
+
+    @Test
+    void build_singlePrimaryRecipient_toHeaderContainsRecipientAddress()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert
+        Address[] toAddresses = message.getRecipients(RecipientType.TO);
+        assertThat(toAddresses).isNotNull().hasSize(1);
+        assertThat(toAddresses[0].toString()).isEqualTo("recruiter@example.com");
+    }
+
+    @Test
+    void build_singlePrimaryRecipient_noUnexpectedCcOrBcc()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange: the validSingleRecipient fixture has no cc or bcc.
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert: recipient arrays for CC and BCC should be null when not set.
+        assertThat(message.getRecipients(RecipientType.CC)).isNullOrEmpty();
+        assertThat(message.getRecipients(RecipientType.BCC)).isNullOrEmpty();
+    }
+
+    // -------------------------------------------------------------------------
+    // build — multiple recipients with cc and bcc
+    // -------------------------------------------------------------------------
+
+    @Test
+    void build_multipleToRecipients_toHeaderContainsAllAddresses()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange: fixture has alice and bob as primary recipients.
+        SendMessageDTO dto = SendMessageRequestFixtures.validMultiRecipientWithCcAndBcc();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert
+        Address[] toAddresses = message.getRecipients(RecipientType.TO);
+        assertThat(toAddresses).isNotNull().hasSize(2);
+        assertThat(toAddresses[0].toString()).isEqualTo("alice@example.com");
+        assertThat(toAddresses[1].toString()).isEqualTo("bob@example.com");
+    }
+
+    @Test
+    void build_ccRecipientPresent_ccHeaderContainsAddress()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validMultiRecipientWithCcAndBcc();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert
+        Address[] ccAddresses = message.getRecipients(RecipientType.CC);
+        assertThat(ccAddresses).isNotNull().hasSize(1);
+        assertThat(ccAddresses[0].toString()).isEqualTo("cc-recipient@example.com");
+    }
+
+    @Test
+    void build_bccRecipientPresent_bccHeaderContainsAddress()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validMultiRecipientWithCcAndBcc();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert
+        Address[] bccAddresses = message.getRecipients(RecipientType.BCC);
+        assertThat(bccAddresses).isNotNull().hasSize(1);
+        assertThat(bccAddresses[0].toString()).isEqualTo("bcc-recipient@example.com");
+    }
+
+    @Test
+    void build_multipleToWithCcAndBcc_allThreeRecipientTypeArraysPopulated()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange: fixture has to=[alice, bob], cc=[cc-recipient], bcc=[bcc-recipient]
+        SendMessageDTO dto = SendMessageRequestFixtures.validMultiRecipientWithCcAndBcc();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert: all three recipient arrays are non-null and sized as expected.
+        assertThat(message.getRecipients(RecipientType.TO)).isNotNull().hasSize(2);
+        assertThat(message.getRecipients(RecipientType.CC)).isNotNull().hasSize(1);
+        assertThat(message.getRecipients(RecipientType.BCC)).isNotNull().hasSize(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // build — subject
+    // -------------------------------------------------------------------------
+
+    @Test
+    void build_dtoWithSubject_subjectHeaderPreservedExactly()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert: subject must round-trip without modification.
+        assertThat(message.getSubject())
+                .isEqualTo("Software Engineer – Application Follow-up");
+    }
+
+    @Test
+    void build_subjectWithSpecialCharacters_subjectHeaderPreservedExactly()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange: subject with non-ASCII (em-dash already in the fixture, but
+        // here we explicitly test Unicode round-trip with accented chars).
+        SendMessageDTO dto = new SendMessageDTO(
+                java.util.List.of("someone@example.com"),
+                null,
+                null,
+                "Réponse à votre annonce – Développeur",
+                "Body text",
+                "text"
+        );
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert
+        assertThat(message.getSubject())
+                .isEqualTo("Réponse à votre annonce – Développeur");
+    }
+
+    // -------------------------------------------------------------------------
+    // build — content type: text/plain
+    // -------------------------------------------------------------------------
+
+    @Test
+    void build_dtoWithTextBodyType_contentTypeStartsWithTextPlain()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert: content type must begin with "text/plain" regardless of
+        // trailing charset parameter ordering.
+        String contentType = MimeMessageTestUtil.getHeader(message, "Content-Type");
+        assertThat(contentType).startsWith("text/plain");
+    }
+
+    @Test
+    void build_dtoWithTextBodyType_contentTypeIncludesUtf8Charset()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert: charset must be UTF-8 so international characters survive encoding.
+        String contentType = MimeMessageTestUtil.getHeader(message, "Content-Type");
+        assertThat(contentType).containsIgnoringCase("charset=UTF-8");
+    }
+
+    // -------------------------------------------------------------------------
+    // build — content type: text/html
+    // -------------------------------------------------------------------------
+
+    @Test
+    void build_dtoWithHtmlBodyType_contentTypeStartsWithTextHtml()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validHtmlBody();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert
+        String contentType = MimeMessageTestUtil.getHeader(message, "Content-Type");
+        assertThat(contentType).startsWith("text/html");
+    }
+
+    @Test
+    void build_dtoWithHtmlBodyType_contentTypeIncludesUtf8Charset()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validHtmlBody();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert
+        String contentType = MimeMessageTestUtil.getHeader(message, "Content-Type");
+        assertThat(contentType).containsIgnoringCase("charset=UTF-8");
+    }
+
+    // -------------------------------------------------------------------------
+    // build — body content round-trip
+    // -------------------------------------------------------------------------
+
+    @Test
+    void build_dtoWithTextBody_bodyContentRoundTrips()
+            throws Exception {
+
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+        String expectedBody = dto.body();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert: getContent() returns the body as a String for simple text/plain
+        // messages (Jakarta Mail decodes the transport encoding automatically).
+        Object content = message.getContent();
+        assertThat(content).isInstanceOf(String.class);
+        assertThat((String) content).isEqualTo(expectedBody);
+    }
+
+    @Test
+    void build_dtoWithHtmlBody_htmlBodyContentRoundTrips()
+            throws Exception {
+
+        // Arrange
+        SendMessageDTO dto = SendMessageRequestFixtures.validHtmlBody();
+        String expectedHtmlBody = dto.body();
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert: HTML body must be forwarded verbatim (Decision 7, no sanitization).
+        Object content = message.getContent();
+        assertThat(content).isInstanceOf(String.class);
+        assertThat((String) content).isEqualTo(expectedHtmlBody);
+    }
+
+    // -------------------------------------------------------------------------
+    // build — bodyType case insensitivity
+    // -------------------------------------------------------------------------
+
+    @Test
+    void build_dtoWithUpperCaseHtmlBodyType_contentTypeStartsWithTextHtml()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange: the builder uses equalsIgnoreCase for bodyType comparison.
+        SendMessageDTO dto = new SendMessageDTO(
+                java.util.List.of("someone@example.com"),
+                null,
+                null,
+                "Test Subject",
+                "<p>Hello</p>",
+                "HTML"   // uppercase — should still map to text/html
+        );
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert
+        String contentType = MimeMessageTestUtil.getHeader(message, "Content-Type");
+        assertThat(contentType).startsWith("text/html");
+    }
+
+    @Test
+    void build_dtoWithNullBodyTypeDefaultedToText_contentTypeStartsWithTextPlain()
+            throws MessagingException, UnsupportedEncodingException {
+
+        // Arrange: null bodyType is normalized to "text" by SendMessageDTO's compact
+        // constructor, so the builder always receives a non-null value in practice.
+        // Verify the builder handles the "text" value correctly.
+        SendMessageDTO dto = new SendMessageDTO(
+                java.util.List.of("someone@example.com"),
+                null,
+                null,
+                "Test Subject",
+                "Body text",
+                null  // compact constructor defaults to "text"
+        );
+
+        // Act
+        MimeMessage message = builder.build(dto);
+
+        // Assert: default "text" bodyType must produce text/plain.
+        String contentType = MimeMessageTestUtil.getHeader(message, "Content-Type");
+        assertThat(contentType).startsWith("text/plain");
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/util/MimeMessageTestUtil.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/util/MimeMessageTestUtil.java
@@ -1,0 +1,121 @@
+package com.aucontraire.gmailbuddy.util;
+
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.internet.MimeMessage;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Base64;
+import java.util.Properties;
+
+/**
+ * Test utility for decoding a base64url-encoded raw Gmail message payload back
+ * into a {@link MimeMessage} for structural assertion in unit tests.
+ *
+ * <p>Gmail's API returns raw MIME content encoded as base64url in
+ * {@code Message.getRaw()}. Tests that verify MimeMessage construction (e.g.,
+ * {@code MimeMessageBuilderTest}, repository round-trip tests) need a way to
+ * reconstruct the {@link MimeMessage} from that wire encoding so they can assert
+ * on individual headers and the body rather than on the opaque encoded string.</p>
+ *
+ * <h2>Usage</h2>
+ * <pre>{@code
+ * // Given a Gmail Message whose raw field was set by MimeMessageBuilder:
+ * String raw = gmailMessage.getRaw(); // base64url-encoded MIME bytes
+ * MimeMessage mime = MimeMessageTestUtil.fromBase64Url(raw);
+ * assertThat(MimeMessageTestUtil.getHeader(mime, "Subject")).isEqualTo("Hello");
+ * }</pre>
+ *
+ * <h2>Design notes</h2>
+ * <ul>
+ *   <li>Uses {@code Base64.getUrlDecoder()} (not the standard decoder) because
+ *       Gmail's API uses base64url encoding as defined by RFC 4648 §5.</li>
+ *   <li>Constructs a no-op {@link Session} (no transport properties needed) so
+ *       there is no dependency on any mail server or SMTP configuration.</li>
+ *   <li>This class is intentionally NOT a Spring {@code @Component}; it is a
+ *       pure-static utility for test code only.</li>
+ * </ul>
+ *
+ * <p>Used by: T031 ({@code MimeMessageBuilderTest}), T034
+ * ({@code GmailRepositoryImplCreateDraftTest}), T037
+ * ({@code CreateDraftIntegrationTest}), T038, T041, T044, T048.</p>
+ */
+public final class MimeMessageTestUtil {
+
+    // Utility class — no instances.
+    private MimeMessageTestUtil() {
+        throw new AssertionError("MimeMessageTestUtil is a static utility class and must not be instantiated");
+    }
+
+    /**
+     * Decodes a base64url-encoded raw Gmail message string into a
+     * {@link MimeMessage}.
+     *
+     * <p>This is the inverse of the encoding step performed by
+     * {@code MimeMessageBuilder}: serialise {@link MimeMessage} bytes →
+     * base64url-encode → store in {@code Message.setRaw(...)}. This method
+     * reverses that operation so tests can assert on individual MIME
+     * headers and body parts.</p>
+     *
+     * @param base64UrlRaw the base64url-encoded raw MIME bytes as returned by
+     *                     {@code com.google.api.services.gmail.model.Message#getRaw()}
+     * @return a fully parsed {@link MimeMessage}
+     * @throws MessagingException if the decoded bytes do not represent valid MIME
+     * @throws IOException        if the byte-array stream cannot be read (should never
+     *                            happen in practice but declared to keep callers honest)
+     * @throws IllegalArgumentException if {@code base64UrlRaw} is {@code null} or blank
+     */
+    public static MimeMessage fromBase64Url(String base64UrlRaw)
+            throws MessagingException, IOException {
+
+        if (base64UrlRaw == null || base64UrlRaw.isBlank()) {
+            throw new IllegalArgumentException(
+                    "base64UrlRaw must not be null or blank — was the raw payload actually set?");
+        }
+
+        byte[] mimeBytes = Base64.getUrlDecoder().decode(base64UrlRaw);
+        InputStream in = new ByteArrayInputStream(mimeBytes);
+
+        // A no-properties Session is sufficient for parsing an already-encoded
+        // MIME message; no SMTP transport is involved.
+        Session noOpSession = Session.getInstance(new Properties());
+        return new MimeMessage(noOpSession, in);
+    }
+
+    /**
+     * Returns the first value of a named MIME header from a decoded
+     * {@link MimeMessage}, or {@code null} if the header is absent.
+     *
+     * <p>Header names are case-insensitive per RFC 5322; the underlying
+     * {@link MimeMessage#getHeader(String)} implementation handles this.</p>
+     *
+     * <p>Typical use: assert the {@code Subject} header value, or the
+     * {@code Content-Type} of the message body:</p>
+     *
+     * <pre>{@code
+     * assertThat(MimeMessageTestUtil.getHeader(mime, "Subject"))
+     *     .isEqualTo("Hello, world");
+     * assertThat(MimeMessageTestUtil.getHeader(mime, "Content-Type"))
+     *     .startsWith("text/plain");
+     * }</pre>
+     *
+     * @param message    the {@link MimeMessage} to query
+     * @param headerName the RFC 5322 header name (e.g., {@code "Subject"},
+     *                   {@code "To"}, {@code "Content-Type"})
+     * @return the first value of the header, or {@code null} if not present
+     * @throws MessagingException if the underlying MIME parsing fails
+     * @throws IllegalArgumentException if {@code message} is {@code null}
+     */
+    public static String getHeader(MimeMessage message, String headerName)
+            throws MessagingException {
+
+        if (message == null) {
+            throw new IllegalArgumentException("message must not be null");
+        }
+
+        String[] values = message.getHeader(headerName);
+        return (values != null && values.length > 0) ? values[0] : null;
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/validation/MaxBodySizeValidatorTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/validation/MaxBodySizeValidatorTest.java
@@ -1,0 +1,264 @@
+package com.aucontraire.gmailbuddy.validation;
+
+import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.util.unit.DataSize;
+
+import java.lang.reflect.Field;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link MaxBodySizeValidator}.
+ *
+ * <h2>Injection approach</h2>
+ * <p>{@link MaxBodySizeValidator} uses {@code @Autowired} field injection of
+ * {@link GmailBuddyProperties} because Hibernate Validator manages the
+ * validator lifecycle (it cannot receive constructor arguments). To keep this
+ * test a pure unit test with zero Spring context overhead, the
+ * {@code gmailBuddyProperties} field is set via reflection in {@link #setUp()}.
+ * A hand-rolled {@link GmailBuddyProperties} stub is constructed directly using
+ * the record canonical constructor — no mocking of the properties object itself.</p>
+ *
+ * <p>Test naming follows the project convention:
+ * {@code methodName_stateUnderTest_expectedBehavior}.</p>
+ */
+class MaxBodySizeValidatorTest {
+
+    /** 10 MB in bytes — matches the production default for gmail-buddy.send.max-body-size. */
+    private static final long TEN_MB_BYTES = 10L * 1024L * 1024L;
+
+    private MaxBodySizeValidator validator;
+
+    @Mock
+    private ConstraintValidatorContext context;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        validator = new MaxBodySizeValidator();
+
+        // Inject a hand-rolled GmailBuddyProperties with max-body-size=10MB via
+        // reflection. This avoids a Spring context while exercising the real
+        // validator logic against a realistic configuration object.
+        GmailBuddyProperties properties = buildTestProperties(DataSize.ofBytes(TEN_MB_BYTES));
+        injectProperties(validator, properties);
+    }
+
+    // -------------------------------------------------------------------------
+    // isValid — null and presence
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isValid_nullBody_returnsTrue() {
+        // Arrange: presence enforcement is @NotBlank's responsibility.
+        // The validator must return true for null so annotations compose cleanly.
+
+        // Act
+        boolean result = validator.isValid(null, context);
+
+        // Assert
+        assertThat(result).isTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // isValid — size boundaries (ASCII / single-byte UTF-8)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isValid_bodyWellBelowLimit_returnsTrue() {
+        // Arrange: a typical short plain-text email body.
+        String shortBody = "Hi there,\n\nI wanted to follow up.\n\nBest regards";
+
+        // Act
+        boolean result = validator.isValid(shortBody, context);
+
+        // Assert
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isValid_bodyAtExactLimit_returnsTrue() {
+        // Arrange: 10 MB of ASCII 'A' characters.  Each 'A' is exactly 1 UTF-8
+        // byte, so character count equals byte count — limit is exactly hit.
+        String exactLimitBody = "A".repeat((int) TEN_MB_BYTES);
+
+        // Act
+        boolean result = validator.isValid(exactLimitBody, context);
+
+        // Assert
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isValid_bodyOneByteAboveLimit_returnsFalse() {
+        // Arrange: 10 MB + 1 ASCII byte — just over the ceiling.
+        String overLimitBody = "A".repeat((int) TEN_MB_BYTES + 1);
+
+        // Act
+        boolean result = validator.isValid(overLimitBody, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isValid_bodySignificantlyAboveLimit_returnsFalse() {
+        // Arrange: the same oversized body produced by SendMessageRequestFixtures.
+        // 1 KiB unit × 10 241 = 10 241 KiB > 10 240 KiB (= 10 MB).
+        String oversizedBody = "A".repeat(1024).repeat(10_241);
+
+        // Act
+        boolean result = validator.isValid(oversizedBody, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // isValid — UTF-8 multi-byte character handling
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isValid_multiBytUtf8CharsExceedLimitByByteCount_returnsFalse() {
+        // Arrange: use a 4-byte UTF-8 emoji (U+1F600 GRINNING FACE).
+        // Each emoji occupies 4 bytes in UTF-8 but only 2 Java chars (a surrogate pair).
+        // With a tiny 10-byte limit, 3 emojis = 12 bytes > 10 bytes, but only 6 chars.
+        // This verifies the validator is byte-aware, not character-aware.
+        String emoji = "😀"; // U+1F600 — 4 UTF-8 bytes, 2 Java chars
+        // 3 emojis = 12 UTF-8 bytes, which exceeds a 10-byte limit
+        String threeEmojis = emoji.repeat(3);
+
+        MaxBodySizeValidator tinyLimitValidator = new MaxBodySizeValidator();
+        GmailBuddyProperties tinyProps = buildTestProperties(DataSize.ofBytes(10));
+        injectPropertiesUnchecked(tinyLimitValidator, tinyProps);
+
+        // Sanity: confirm char count < byte count for this string
+        assertThat((long) threeEmojis.length()).isLessThan(12L);
+
+        // Act
+        boolean result = tinyLimitValidator.isValid(threeEmojis, context);
+
+        // Assert: must be rejected on byte count (12 bytes > 10 byte limit),
+        // even though character count (6 chars) is below 10.
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isValid_multiBytUtf8CharsWithinLimitByByteCount_returnsTrue() {
+        // Arrange: 2 emojis = 8 UTF-8 bytes; within a 10-byte limit.
+        String emoji = "😀"; // U+1F600 — 4 UTF-8 bytes, 2 Java chars
+        String twoEmojis = emoji.repeat(2); // 8 bytes, 4 Java chars
+
+        MaxBodySizeValidator tinyLimitValidator = new MaxBodySizeValidator();
+        GmailBuddyProperties tinyProps = buildTestProperties(DataSize.ofBytes(10));
+        injectPropertiesUnchecked(tinyLimitValidator, tinyProps);
+
+        // Act
+        boolean result = tinyLimitValidator.isValid(twoEmojis, context);
+
+        // Assert: 8 bytes <= 10-byte limit — must be accepted.
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isValid_nonAsciiMultiByteString_byteCountEnforced_returnsFalse() {
+        // Arrange: Japanese characters each occupy 3 UTF-8 bytes.
+        // 4 chars × 3 bytes = 12 bytes > 10-byte limit.
+        String fourJapanese = "日本語テ"; // 4 × 3 UTF-8 bytes = 12 bytes; 4 Java chars
+
+        MaxBodySizeValidator tinyLimitValidator = new MaxBodySizeValidator();
+        GmailBuddyProperties tinyProps = buildTestProperties(DataSize.ofBytes(10));
+        injectPropertiesUnchecked(tinyLimitValidator, tinyProps);
+
+        // Act
+        boolean result = tinyLimitValidator.isValid(fourJapanese, context);
+
+        // Assert: 12 bytes > 10 — must be rejected.
+        assertThat(result).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Builds a minimal {@link GmailBuddyProperties} with the given
+     * {@code maxBodySize}. All other nested records carry placeholder values that
+     * satisfy their constraints; they are not exercised by these tests.
+     */
+    private static GmailBuddyProperties buildTestProperties(DataSize maxBodySize) {
+        return new GmailBuddyProperties(
+                new GmailBuddyProperties.GmailApi(
+                        "Test App",
+                        "me",
+                        50,
+                        100L,
+                        new GmailBuddyProperties.GmailApi.RateLimit(60L,
+                                new GmailBuddyProperties.GmailApi.RateLimit.BatchOperations(
+                                        1000L, 3, 1000L, 2.0, 30000L, 50, 0L)),
+                        new GmailBuddyProperties.GmailApi.ServiceUnavailable(60L),
+                        new GmailBuddyProperties.GmailApi.MessageProcessing(
+                                new GmailBuddyProperties.GmailApi.MessageProcessing.MimeTypes(
+                                        "text/html", "text/plain"),
+                                new GmailBuddyProperties.GmailApi.MessageProcessing.Labels("UNREAD")),
+                        new GmailBuddyProperties.GmailApi.QueryOperators(
+                                "from:", "to:", "subject:", "has:attachment", "label:", " AND ")),
+                new GmailBuddyProperties.OAuth2(
+                        "google",
+                        new GmailBuddyProperties.OAuth2.Token("Bearer ")),
+                new GmailBuddyProperties.ErrorHandling(
+                        new GmailBuddyProperties.ErrorHandling.ErrorCodes(
+                                "RATE_LIMIT_EXCEEDED", "SERVICE_UNAVAILABLE", "VALIDATION_ERROR",
+                                "CONSTRAINT_VIOLATION", "GMAIL_SERVICE_ERROR", "MESSAGE_NOT_FOUND",
+                                "AUTHENTICATION_ERROR", "AUTHORIZATION_ERROR", "RESOURCE_NOT_FOUND",
+                                "GMAIL_API_ERROR", "INTERNAL_SERVER_ERROR"),
+                        new GmailBuddyProperties.ErrorHandling.ErrorCategories(
+                                "CLIENT_ERROR", "SERVER_ERROR")),
+                new GmailBuddyProperties.Validation(
+                        new GmailBuddyProperties.Validation.GmailQuery(
+                                "<script>", "^[a-zA-Z0-9]+$"),
+                        new GmailBuddyProperties.Validation.Email(
+                                "^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$")),
+                new GmailBuddyProperties.Security(
+                        new String[]{"/actuator/health"},
+                        new GmailBuddyProperties.Security.OAuth2Security(
+                                "/dashboard", "/oauth2/authorization/google")),
+                new GmailBuddyProperties.Environment(
+                        new GmailBuddyProperties.Environment.EnvFile("./", ".env")),
+                new GmailBuddyProperties.ApplicationRateLimit(1000, 60),
+                new GmailBuddyProperties.Send(maxBodySize, 500, 998)
+        );
+    }
+
+    /**
+     * Injects {@code properties} into the {@code gmailBuddyProperties} field of
+     * {@code target} via reflection, mimicking what Spring's
+     * {@code SpringConstraintValidatorFactory} does at runtime.
+     *
+     * @throws Exception if the field cannot be accessed
+     */
+    private static void injectProperties(MaxBodySizeValidator target,
+                                         GmailBuddyProperties properties) throws Exception {
+        Field field = MaxBodySizeValidator.class.getDeclaredField("gmailBuddyProperties");
+        field.setAccessible(true);
+        field.set(target, properties);
+    }
+
+    /**
+     * Unchecked wrapper around {@link #injectProperties} for use inside lambdas.
+     */
+    private static void injectPropertiesUnchecked(MaxBodySizeValidator target,
+                                                   GmailBuddyProperties properties) {
+        try {
+            injectProperties(target, properties);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to inject GmailBuddyProperties via reflection", e);
+        }
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjectionValidatorTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjectionValidatorTest.java
@@ -1,0 +1,203 @@
+package com.aucontraire.gmailbuddy.validation;
+
+import jakarta.validation.ConstraintValidatorContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link NoHeaderInjectionValidator}.
+ *
+ * <p>Each test instantiates the validator in isolation — no Spring context is
+ * required — and verifies one logical behaviour. The {@link ConstraintValidatorContext}
+ * is mocked because the validator never reads it; it is only part of the API
+ * signature mandated by the Bean Validation specification.</p>
+ *
+ * <p>Test naming follows the project convention:
+ * {@code methodName_stateUnderTest_expectedBehavior}.</p>
+ */
+class NoHeaderInjectionValidatorTest {
+
+    private NoHeaderInjectionValidator validator;
+
+    @Mock
+    private ConstraintValidatorContext context;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        validator = new NoHeaderInjectionValidator();
+    }
+
+    // -------------------------------------------------------------------------
+    // isValid — null and empty inputs
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isValid_nullValue_returnsTrue() {
+        // Arrange: presence enforcement is @NotBlank's responsibility, not this validator's.
+        // A null value must be treated as valid so the two annotations compose cleanly.
+
+        // Act
+        boolean result = validator.isValid(null, context);
+
+        // Assert
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isValid_emptyString_returnsTrue() {
+        // Arrange: an empty string contains no injection characters.
+
+        // Act
+        boolean result = validator.isValid("", context);
+
+        // Assert
+        assertThat(result).isTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // isValid — clean strings (no injection characters)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isValid_cleanString_returnsTrue() {
+        // Arrange
+        String cleanSubject = "Software Engineer – Application Follow-up";
+
+        // Act
+        boolean result = validator.isValid(cleanSubject, context);
+
+        // Assert
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    void isValid_cleanEmailAddress_returnsTrue() {
+        // Arrange
+        String email = "recruiter@example.com";
+
+        // Act
+        boolean result = validator.isValid(email, context);
+
+        // Assert
+        assertThat(result).isTrue();
+    }
+
+    // -------------------------------------------------------------------------
+    // isValid — carriage return (\r) only
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isValid_carriageReturnOnly_returnsFalse() {
+        // Arrange: a standalone \r (U+000D) is sufficient to terminate a header
+        // line in some older parsers; must be rejected regardless of \n presence.
+        String withCr = "Legitimate Subject\rX-Injected-Header: malicious";
+
+        // Act
+        boolean result = validator.isValid(withCr, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isValid_valueIsOnlyCarriageReturn_returnsFalse() {
+        // Arrange
+        String onlyCr = "\r";
+
+        // Act
+        boolean result = validator.isValid(onlyCr, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // isValid — line feed (\n) only
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isValid_lineFeedOnly_returnsFalse() {
+        // Arrange: a standalone \n (U+000A) also terminates a header line.
+        String withLf = "Legitimate Subject\nX-Injected-Header: malicious";
+
+        // Act
+        boolean result = validator.isValid(withLf, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isValid_valueIsOnlyLineFeed_returnsFalse() {
+        // Arrange
+        String onlyLf = "\n";
+
+        // Act
+        boolean result = validator.isValid(onlyLf, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // isValid — CRLF pair (\r\n)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isValid_crlfPair_returnsFalse() {
+        // Arrange: the canonical HTTP/SMTP header-injection vector uses \r\n together.
+        String withCrlf = "Legitimate Subject\r\nX-Injected-Header: malicious";
+
+        // Act
+        boolean result = validator.isValid(withCrlf, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isValid_subjectWithCarriageReturn_returnsFalse() {
+        // Arrange: per FR-015, any \r in a header-bound field must be rejected.
+        // This exercises the exact subject-injection pattern from the spec edge cases.
+        String injectionAttempt = "Hello\rBcc: attacker@evil.com";
+
+        // Act
+        boolean result = validator.isValid(injectionAttempt, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    // -------------------------------------------------------------------------
+    // isValid — injection character at different positions
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isValid_injectionCharacterAtStart_returnsFalse() {
+        // Arrange: validator must catch injection regardless of position.
+        String startsWithLf = "\nInjected";
+
+        // Act
+        boolean result = validator.isValid(startsWithLf, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isValid_injectionCharacterAtEnd_returnsFalse() {
+        // Arrange
+        String endsWithCr = "Normal text\r";
+
+        // Act
+        boolean result = validator.isValid(endsWithCr, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjectionValidatorTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/validation/NoHeaderInjectionValidatorTest.java
@@ -200,4 +200,74 @@ class NoHeaderInjectionValidatorTest {
         // Assert
         assertThat(result).isFalse();
     }
+
+    // -------------------------------------------------------------------------
+    // isValid — additional Unicode line-terminator characters (defence-in-depth)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void isValid_valueWithNextLineCharacter_returnsFalse() {
+        // Arrange: U+0085 NEXT LINE is a Unicode line terminator recognised by the
+        // Java Language Specification and various parsers; must be rejected as
+        // defence-in-depth even though current call sites encode it via RFC 2047.
+        String withNel = "SubjectX-Injected-Header: malicious";
+
+        // Act
+        boolean result = validator.isValid(withNel, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isValid_valueWithVerticalTab_returnsFalse() {
+        // Arrange: U+000B VERTICAL TAB is a line terminator per the Unicode Standard
+        // and the Java Language Specification; must be rejected as defence-in-depth.
+        String withVt = "SubjectX-Injected-Header: malicious";
+
+        // Act
+        boolean result = validator.isValid(withVt, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isValid_valueWithFormFeed_returnsFalse() {
+        // Arrange: U+000C FORM FEED is a line terminator per the Unicode Standard
+        // and the Java Language Specification; must be rejected as defence-in-depth.
+        String withFf = "SubjectX-Injected-Header: malicious";
+
+        // Act
+        boolean result = validator.isValid(withFf, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isValid_valueWithUnicodeLineSeparator_returnsFalse() {
+        // Arrange: U+2028 LINE SEPARATOR is the Unicode-native line terminator;
+        // some parsers treat it identically to LF and must therefore be rejected.
+        String withLs = "Subject X-Injected-Header: malicious";
+
+        // Act
+        boolean result = validator.isValid(withLs, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    void isValid_valueWithUnicodeParagraphSeparator_returnsFalse() {
+        // Arrange: U+2029 PARAGRAPH SEPARATOR is a Unicode line terminator that
+        // some parsers treat as a block boundary; must be rejected as defence-in-depth.
+        String withPs = "Subject X-Injected-Header: malicious";
+
+        // Act
+        boolean result = validator.isValid(withPs, context);
+
+        // Assert
+        assertThat(result).isFalse();
+    }
 }

--- a/src/test/java/com/aucontraire/gmailbuddy/validation/SendMessageValidationTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/validation/SendMessageValidationTest.java
@@ -1,0 +1,359 @@
+package com.aucontraire.gmailbuddy.validation;
+
+import com.aucontraire.gmailbuddy.controller.GmailController;
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
+import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
+import com.aucontraire.gmailbuddy.ratelimit.RateLimitService;
+import com.aucontraire.gmailbuddy.security.TokenReferenceService;
+import com.aucontraire.gmailbuddy.service.GmailService;
+import com.aucontraire.gmailbuddy.service.GoogleTokenValidator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Validation-slice tests for {@code POST /api/v1/gmail/drafts}.
+ *
+ * <p>Covers all Bean Validation failure scenarios for the
+ * {@link com.aucontraire.gmailbuddy.dto.SendMessageDTO} payload when submitted to
+ * the create-draft endpoint. The happy-path 201 contract is tested separately in
+ * {@code CreateDraftControllerTest} (T036).</p>
+ *
+ * <p>Uses {@code @WebMvcTest} to load only the web layer (controller +
+ * {@code GlobalExceptionHandler}) so tests run fast without a full Spring context.
+ * All service-layer dependencies are mocked with {@code @MockitoBean}.</p>
+ *
+ * <p>Key conventions:</p>
+ * <ul>
+ *   <li>Test method names follow {@code methodName_stateUnderTest_expectedBehavior}.</li>
+ *   <li>Arrange-Act-Assert sections are clearly separated.</li>
+ *   <li>Each test validates exactly one logical validation behaviour.</li>
+ * </ul>
+ */
+@WebMvcTest(GmailController.class)
+@Import(TestGmailBuddyPropertiesConfiguration.class)
+@DisplayName("POST /api/v1/gmail/drafts — validation slice")
+class SendMessageValidationTest {
+
+    private static final String DRAFTS_ENDPOINT = "/api/v1/gmail/drafts";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private GmailService gmailService;
+
+    @MockitoBean
+    private OAuth2AuthorizedClientService authorizedClientService;
+
+    @MockitoBean
+    private GoogleTokenValidator tokenValidator;
+
+    @MockitoBean
+    private TokenReferenceService tokenReferenceService;
+
+    @MockitoBean
+    private ResponseMapper responseMapper;
+
+    @MockitoBean
+    private RateLimitService rateLimitService;
+
+    @MockitoBean
+    private GmailQuotaEstimator gmailQuotaEstimator;
+
+    // -------------------------------------------------------------------------
+    // Recipient list — empty / missing
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_emptyToList_returns400WithFieldExtension")
+    void postDraft_emptyToList_returns400WithFieldExtension() throws Exception {
+        // Arrange: a DTO whose "to" list is explicitly empty; @NotEmpty must reject it.
+        SendMessageDTO dto = SendMessageRequestFixtures.invalidEmptyToList();
+        String body = objectMapper.writeValueAsString(dto);
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("/problems/validation-error"))
+                .andExpect(jsonPath("$.title").value("Validation Error"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.extensions['field:to']").exists());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_missingToField_returns400WithFieldExtension")
+    void postDraft_missingToField_returns400WithFieldExtension() throws Exception {
+        // Arrange: explicit null "to" field to verify null/absent list produces same error.
+        // The compact constructor normalises null→empty-list, so the @NotEmpty fires.
+        SendMessageDTO dto = new SendMessageDTO(
+                null,
+                null,
+                null,
+                "Valid Subject",
+                "Valid body content",
+                "text"
+        );
+        String body = objectMapper.writeValueAsString(dto);
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("/problems/validation-error"))
+                .andExpect(jsonPath("$.extensions['field:to']").exists());
+    }
+
+    // -------------------------------------------------------------------------
+    // Recipient list — malformed email at element index
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_malformedEmailAtToIndex1_returns400WithConstraintExtension")
+    void postDraft_malformedEmailAtToIndex1_returns400WithConstraintExtension() throws Exception {
+        // Arrange: first recipient is valid; second is malformed.
+        // The constraint path reported by Bean Validation for a TYPE_USE constraint
+        // on a list element follows the pattern "to[1].<list element>".
+        SendMessageDTO dto = new SendMessageDTO(
+                List.of("valid@example.com", "not-an-email"),
+                null,
+                null,
+                "Valid Subject",
+                "Valid body content",
+                "text"
+        );
+        String body = objectMapper.writeValueAsString(dto);
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("/problems/validation-error"))
+                .andExpect(jsonPath("$.status").value(400))
+                // The GlobalExceptionHandler puts constraint-path keys under "constraint:" prefix
+                // for ConstraintViolationException; for MethodArgumentNotValidException it uses
+                // "field:" prefix with the field name only. We assert the error exists for "to".
+                .andExpect(jsonPath("$.extensions").exists());
+    }
+
+    // -------------------------------------------------------------------------
+    // Subject — oversized (> 998 chars)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_oversizedSubject_returns400WithFieldExtension")
+    void postDraft_oversizedSubject_returns400WithFieldExtension() throws Exception {
+        // Arrange: subject of 999 characters exceeds the @Size(max=998) constraint.
+        String oversizedSubject = "A".repeat(999);
+        SendMessageDTO dto = new SendMessageDTO(
+                List.of("recruiter@example.com"),
+                null,
+                null,
+                oversizedSubject,
+                "Valid body content",
+                "text"
+        );
+        String body = objectMapper.writeValueAsString(dto);
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("/problems/validation-error"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.extensions['field:subject']").exists());
+    }
+
+    // -------------------------------------------------------------------------
+    // Body — oversized (> 10 MB)
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_oversizedBody_returns400WithFieldExtension")
+    void postDraft_oversizedBody_returns400WithFieldExtension() throws Exception {
+        // Arrange: body that exceeds the 10 MB @MaxBodySize limit.
+        // SendMessageRequestFixtures.invalidOversizedBody() produces ~10 MB + 1 KB of ASCII.
+        SendMessageDTO dto = SendMessageRequestFixtures.invalidOversizedBody();
+        String body = objectMapper.writeValueAsString(dto);
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("/problems/validation-error"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.extensions['field:body']").exists());
+    }
+
+    // -------------------------------------------------------------------------
+    // Missing required fields — no body / no subject
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_missingSubject_returns400WithFieldExtension")
+    void postDraft_missingSubject_returns400WithFieldExtension() throws Exception {
+        // Arrange: no subject provided; @NotBlank must reject it.
+        String rawJson = """
+                {
+                  "to": ["recruiter@example.com"],
+                  "body": "Hello"
+                }
+                """;
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(rawJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("/problems/validation-error"))
+                .andExpect(jsonPath("$.extensions['field:subject']").exists());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_missingBody_returns400WithFieldExtension")
+    void postDraft_missingBody_returns400WithFieldExtension() throws Exception {
+        // Arrange: no body provided; @NotBlank must reject it.
+        String rawJson = """
+                {
+                  "to": ["recruiter@example.com"],
+                  "subject": "Hello"
+                }
+                """;
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(rawJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("/problems/validation-error"))
+                .andExpect(jsonPath("$.extensions['field:body']").exists());
+    }
+
+    // -------------------------------------------------------------------------
+    // Header injection — CRLF in subject
+    //
+    // Per FR-015 and FR-018 (SC-005), @NoHeaderInjection violations must return
+    // "/problems/header-injection-detected" so security-relevant attempts can be
+    // triaged separately from ordinary validation failures. The handler inspects
+    // FieldError codes for "NoHeaderInjection" and switches the problem type
+    // accordingly while keeping HTTP status 400 and field-level extensions intact.
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_crlfInSubject_returns400HeaderInjectionDetected")
+    void postDraft_crlfInSubject_returns400ValidationError() throws Exception {
+        // Arrange: subject contains a CRLF injection sequence; @NoHeaderInjection must
+        // reject it with the distinct /problems/header-injection-detected problem type.
+        SendMessageDTO dto = SendMessageRequestFixtures.invalidCrlfInSubject();
+        String body = objectMapper.writeValueAsString(dto);
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("/problems/header-injection-detected"))
+                .andExpect(jsonPath("$.title").value("Header Injection Detected"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.extensions['field:subject']").exists());
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_crlfInRecipient_returns400HeaderInjectionDetected")
+    void postDraft_crlfInRecipient_returns400ValidationError() throws Exception {
+        // Arrange: a "to" recipient contains a CRLF injection sequence; @NoHeaderInjection
+        // must reject it with the distinct /problems/header-injection-detected problem type.
+        SendMessageDTO dto = new SendMessageDTO(
+                List.of("recruiter@example.com\r\nBcc: attacker@evil.com"),
+                null,
+                null,
+                "Valid Subject",
+                "Valid body content",
+                "text"
+        );
+        String body = objectMapper.writeValueAsString(dto);
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("/problems/header-injection-detected"))
+                .andExpect(jsonPath("$.title").value("Header Injection Detected"))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.extensions").exists());
+    }
+
+    // -------------------------------------------------------------------------
+    // Invalid bodyType
+    // -------------------------------------------------------------------------
+
+    @Test
+    @WithMockUser
+    @DisplayName("postDraft_invalidBodyType_returns400WithFieldExtension")
+    void postDraft_invalidBodyType_returns400WithFieldExtension() throws Exception {
+        // Arrange: bodyType value "markdown" is not in the allowed set {text, html}.
+        SendMessageDTO dto = new SendMessageDTO(
+                List.of("recruiter@example.com"),
+                null,
+                null,
+                "Valid Subject",
+                "Valid body content",
+                "markdown"
+        );
+        String body = objectMapper.writeValueAsString(dto);
+
+        // Act & Assert
+        mockMvc.perform(post(DRAFTS_ENDPOINT)
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(body))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.type").value("/problems/validation-error"))
+                .andExpect(jsonPath("$.extensions['field:bodyType']").exists());
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/validation/TestGmailBuddyPropertiesConfiguration.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/validation/TestGmailBuddyPropertiesConfiguration.java
@@ -4,6 +4,7 @@ import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Primary;
+import org.springframework.util.unit.DataSize;
 
 @TestConfiguration
 public class TestGmailBuddyPropertiesConfiguration {
@@ -62,7 +63,8 @@ public class TestGmailBuddyPropertiesConfiguration {
             new GmailBuddyProperties.Environment(
                 new GmailBuddyProperties.Environment.EnvFile("src/main/resources", ".env")
             ),
-            new GmailBuddyProperties.ApplicationRateLimit(1000, 60)
+            new GmailBuddyProperties.ApplicationRateLimit(1000, 60),
+            new GmailBuddyProperties.Send(DataSize.ofMegabytes(10), 500, 998)
         );
     }
 }

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -4,10 +4,15 @@
 # OAuth2 Client Registration for Tests (using dummy values)
 spring.security.oauth2.client.registration.google.client-id=test-client-id
 spring.security.oauth2.client.registration.google.client-secret=test-client-secret
-spring.security.oauth2.client.registration.google.scope=email,profile,https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://mail.google.com
+spring.security.oauth2.client.registration.google.scope=email,profile,https://www.googleapis.com/auth/gmail.readonly,https://www.googleapis.com/auth/gmail.modify,https://www.googleapis.com/auth/gmail.send,https://mail.google.com/
 spring.security.oauth2.client.registration.google.redirect-uri={baseUrl}/login/oauth2/code/{registrationId}
 spring.security.oauth2.client.provider.google.token-uri=https://oauth2.googleapis.com/token
 spring.security.oauth2.client.provider.google.authorization-uri=https://accounts.google.com/o/oauth2/auth
+
+# Send/Draft Endpoint Configuration (mirrors production values for GmailBuddyProperties binding)
+gmail-buddy.send.max-body-size=10MB
+gmail-buddy.send.max-recipients-per-message=500
+gmail-buddy.send.max-subject-length=998
 
 # Disable session security for tests
 server.servlet.session.cookie.secure=false


### PR DESCRIPTION
## Summary

- Adds 3 new POST endpoints so the targeted-job-search Python service can programmatically create Gmail drafts (default path, for LLM-personalized outreach) or send messages directly (trusted templates).
- Introduces 3 new validators (`@NoHeaderInjection`, `@MaxBodySize`, plus an `@OptionalEmail` `@Target` extension), 4 new ProblemDetail URIs, a logback CR/LF sanitization converter, and a boundary mapper to keep Gmail SDK types out of repository signatures.
- Adds `gmail.send` to the OAuth scope set; preserves `mail.google.com` (still required by existing DELETE / `batchDelete` path — see `docs/architecture/SPIKE-002-Send-Email-Endpoint-Readiness.md` §11.1).

## New endpoints

| Endpoint | Status | Quota | Use case |
|---|---|---|---|
| `POST /api/v1/gmail/drafts` | 201 + Location | 10 | Default outreach path — staged for human review in Gmail Drafts folder |
| `POST /api/v1/gmail/drafts/{draftId}/send` | 200 | 100 | Programmatic send after approval; naturally idempotent (404 on retry once the draft is sent) |
| `POST /api/v1/gmail/messages` | 201 + Location | 100 | Direct send for trusted, deterministic templates (no LLM content) |

The 200/201 asymmetry is intentional: send-draft is a state transition on an existing resource; direct-send creates a new message resource.

## Smoke-tested end-to-end

All 3 endpoints validated against live Gmail with a real Bearer token:
- `POST /drafts` returned 201 + DraftResponse; draft visible in Gmail Drafts folder.
- `POST /drafts/{id}/send` returned 200; draft removed from Drafts, message in Sent folder, recipient inbox received the email.
- `POST /messages` returned 201 + Location header; message delivered immediately.
- `X-Gmail-Quota-Used` response header reports 10 / 100 / 100 units respectively, matching Gmail's published costs.

## Test coverage

- **1050 tests pass** (135 new across 19 new test files); 0 failures, 0 errors, 2 pre-existing `@Disabled` skips.
- New-code coverage: 100% on most files; 91% on `GmailController`; 85.7% on `CrlfSanitizingMessageConverter`. SC-008 (≥80% on new code) satisfied.
- Coverage on `GmailRepositoryImpl` and `GmailService` overall is dragged down by pre-existing untested legacy methods; the new methods themselves are 100% covered.
- Test files cover: validators, DTO / builder / mapper, repository (with mocked Gmail SDK chains), service (Mockito delegation), controller slices (`@WebMvcTest`), and Bearer-token + session integration tests.

## Security

- `/security-review` run on the branch — **no HIGH or MEDIUM findings**.
- One defense-in-depth hardening landed during the review: `@NoHeaderInjection` extended to reject 5 additional Unicode line-terminator-class characters (U+000B, U+000C, U+0085, U+2028, U+2029) in addition to `\r`/`\n`. Removes a dependency on downstream RFC 2047 encoding behavior as a backup mitigation.
- Header-injection violations route to a distinct ProblemDetail type (`/problems/header-injection-detected`) so they can be triaged separately from generic validation errors.
- CR/LF in user-supplied log fields (recipient addresses, subject) is sanitized at log-emit time by `CrlfSanitizingMessageConverter` registered in `logback.xml` (FR-024 mitigation).

## Constitution Check

Pass with one documented controlled deviation:

- **Principle VII (Logging)**: this feature deliberately logs recipient email addresses and subject lines (PII) on the success path of `createDraft` and `sendMessage` to deliver diagnostic value ("which recipient failed?", "what email was that?") for the single-user local-machine deployment. The deviation is bounded — log shipping or multi-user mode triggers a revisit — and CR/LF in those values is sanitized to prevent log-injection. Approved during clarification round.

All other 7 principles pass without deviation.

## Out of scope (explicit)

- Threaded replies (`threadId` + `In-Reply-To` / `References` headers) — always starts a new thread
- Send-as alias — always sends from the authenticated user's primary identity
- Attachments — text and HTML body only
- Scheduled delivery — Gmail API doesn't expose `sendAt`
- Approval UI inside gmail-buddy — review happens in Gmail Drafts folder
- API-key auth for TJS — uses the existing Bearer-token path
- Idempotency mechanism — at-least-once contract; callers MUST NOT auto-retry POSTs after timeouts (FR-023)
- Drafts list/get/delete endpoints — deferred to v1.5

## Follow-ups filed in `docs/FOLLOW_UPS.md`

- **FU-001**: configure persistent encryption key for `TokenReferenceService` (operational hardening)
- **FU-002**: Spring `@Autowired` warning on `WebConfig` (cosmetic)
- **FU-003**: `ValidationException` returns HTTP 400 instead of 422 on Gmail `invalidArgument` (contract drift)
- **FU-004**: pre-existing `getMessageBody` logs message body via `toPrettyString` (constitution VII violation in pre-existing code)

None block this PR per CLAUDE.md §A3 (no cosmetic-only mixing with feature work).

## Test plan

- [x] Reviewer verifies `./mvnw test` passes locally (1050 tests, 2 pre-existing `@Disabled` skips)
- [x] Reviewer skims `docs/API_TESTING_GUIDE.md` § "Required Gmail Scopes" to confirm scope-to-endpoint table is accurate
- [x] Reviewer reads `docs/FOLLOW_UPS.md` and accepts the 4 follow-ups
- [x] After merge: first run forces re-consent (existing refresh tokens were invalidated by `gmail.send` scope addition); user re-authorizes via Google's consent screen
- [x] After re-consent: smoke-test the 3 endpoints against live Gmail (scripts available locally; not committed)