### PR TITLE
fix: close PII log leak in getMessageBody and quiet WebConfig autowired warning

### DIFF
--- a/docs/FOLLOW_UPS.md
+++ b/docs/FOLLOW_UPS.md
@@ -31,35 +31,6 @@ Origin: `TokenReferenceService` / `AESEncryptionUtil` (added in the Token Securi
 
 ---
 
-## FU-002 — Resolve Spring `@Autowired` warning on `WebConfig`
-
-**Surfaces as**: startup log entry every time the application boots:
-
-```
-WARN - Inconsistent constructor declaration on bean with name 'webConfig':
-       single autowire-marked constructor flagged as optional - this constructor
-       is effectively required since there is no default constructor to fall
-       back to: public com.aucontraire.gmailbuddy.config.WebConfig$$SpringCGLIB$$0(
-         com.aucontraire.gmailbuddy.config.RateLimitInterceptor)
-```
-
-Origin: pre-existing in `WebConfig.java`. Likely an `@Autowired(required = false)` (or equivalent default-arg pattern) on a constructor that has no fallback default constructor — Spring's warning says: "you marked this optional but I can't actually skip it because there's no other constructor."
-
-**Why it's not blocking**: cosmetic. The bean is constructed correctly; the warning is just noise on every startup.
-
-**Recommended fix** (one of):
-- Remove the `@Autowired` annotation entirely if the constructor is the only one (Spring auto-detects single-constructor injection since 4.3 — explicit annotation is redundant).
-- Or, if `@Autowired(required = false)` was intentional, refactor the constructor to truly support optional injection (e.g., add a default constructor or a no-arg path).
-- Most likely fix: drop the annotation; net change ≈ 1 line.
-
-**Recommended timing**: trivial 1-line commit. Could go in any small docs/cleanup PR (e.g., bundled with the FU-001 fix, or as a one-off chore commit).
-
-Per CLAUDE.md §A3 (Anti-Slop "No Cosmetic-Only Changes"): do NOT bundle this with feature work. Cosmetic-only changes belong in their own commit so feature diffs stay clean.
-
-**Owner (per CLAUDE.md)**: `spring-boot-config-manager` (Spring DI / configuration domain).
-
----
-
 ## FU-003 — `ValidationException` returns HTTP 400 instead of 422
 
 **Surfaces as**: contract drift between `specs/001-send-draft-emails/contracts/api-endpoints.md` (Endpoint 1 error matrix says `400 invalidArgument` from Gmail → `/problems/invalid-recipient` → HTTP **422 Unprocessable Entity**) and the actual production response, which returns HTTP **400 Bad Request**.
@@ -77,40 +48,6 @@ Origin: `ValidationException.getHttpStatus()` returns 400 (used by all Bean Vali
 **Recommended timing**: small follow-up commit on the same branch IF you want the contract to match before merging. Otherwise a focused follow-up PR after merge — the test asserts current behavior so this isn't a regression.
 
 **Owner (per CLAUDE.md)**: `validation-error-handler` (exception hierarchy + GlobalExceptionHandler) with light coordination from `gmail-api-integration` (the mapGmailSendError helper).
-
----
-
-## FU-004 — Existing `getMessageBody` log statement leaks message body content
-
-**Surfaces as**: a constitution VII violation in pre-existing code, discovered during the T062 spot-check of the send/draft feature's deviation. Not introduced by the send/draft feature, but it's the same kind of issue the deviation is bounded against.
-
-**Location**: `src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java`, line 317:
-
-```java
-logger.info("Message retrieved: {}", message.toPrettyString());
-```
-
-`message.toPrettyString()` serializes the entire Gmail API `Message` object including `payload` → `parts` → `body.data` (base64-encoded body content). This means the existing `GET /api/v1/gmail/messages/{messageId}/body` endpoint logs full email body content on every call.
-
-**Why it's a violation**: Constitution Principle VII states *"OAuth tokens, credentials, email bodies, and PII MUST NOT appear in logs."* The body content of every retrieved message is being logged.
-
-**Why it wasn't blocking the send/draft feature**: this is in a DIFFERENT endpoint (the existing message-retrieval path), not in any new send/draft endpoint. The new code we added doesn't log body content. Per CLAUDE.md §A3 ("No Cosmetic-Only Changes" mixed with feature work), this fix belongs in its own commit/PR.
-
-**Recommended fix** (1 line):
-
-```java
-// Before
-logger.info("Message retrieved: {}", message.toPrettyString());
-
-// After
-logger.info("Message retrieved: messageId={}", message.getId());
-```
-
-Optionally also log `getThreadId()` if useful for diagnostics. Do NOT log `toPrettyString()`, `getPayload()`, or anything that traverses to body content.
-
-**Recommended timing**: trivial 1-line follow-up commit. Could be bundled with FU-002 (cosmetic Spring `@Autowired` warning fix) into one tiny chore commit since both are pre-existing-code hygiene.
-
-**Owner (per CLAUDE.md)**: `gmail-api-integration` (Gmail API path) or `security-auth-specialist` (logging-PII concern). Either is appropriate.
 
 ---
 
@@ -167,3 +104,17 @@ The 2 `@Disabled` annotations are pre-existing, not introduced by the send/draft
 - Each entry stays open until the corresponding fix lands; on completion, mark the heading as `~~FU-NNN~~ (resolved in <commit-sha>)` and move to the bottom of the file.
 - Items here are intentionally NOT the same scope as feature spec backlogs (which live under `specs/`); these are cross-cutting nits / operational items / pre-existing tech debt observed during feature work.
 - Scope guideline: prefer FOLLOW_UPS for items that can ship in 1 focused PR. Larger-scope items (deferred features, multi-step initiatives) live in maintainer-side planning notes outside this repo.
+
+---
+
+## Resolved
+
+Resolved entries are kept here for traceability — heading + 1-line summary + fix reference. Full diagnostic detail at the time of filing is in git history.
+
+### ~~FU-002~~ — Spring `@Autowired` warning on `WebConfig` (resolved in PR #11)
+
+Dropped `@Autowired(required = false)` from the sole constructor and the matching null-guard in `addInterceptors`. `RateLimitInterceptor` is unconditionally `@Component`, so the optionality was dead code. Spring no longer emits the "Inconsistent constructor declaration" warning at startup.
+
+### ~~FU-004~~ — `getMessageBody` log statement leaked message body content (resolved in PR #11)
+
+Replaced `message.toPrettyString()` with `message.getId()` on the `getMessageBody` log line, closing a Constitution VII violation (full Gmail SDK `Message` — including `payload.parts.body.data` — was being logged on every `GET /api/v1/gmail/messages/{id}/body` call). Added a Logback `ListAppender`-based regression test asserting the log emits `messageId=…` and no payload/parts/body fragments.

--- a/src/main/java/com/aucontraire/gmailbuddy/config/WebConfig.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/config/WebConfig.java
@@ -1,6 +1,5 @@
 package com.aucontraire.gmailbuddy.config;
 
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.lang.NonNull;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
@@ -12,24 +11,20 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  * not via interceptor, to ensure headers are set before response commit.
  *
  * Registers:
- * - RateLimitInterceptor: Tracks rate limits and estimates Gmail API quota usage (if available)
+ * - RateLimitInterceptor: Tracks rate limits and estimates Gmail API quota usage
  */
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
     private final RateLimitInterceptor rateLimitInterceptor;
 
-    @Autowired(required = false)
     public WebConfig(RateLimitInterceptor rateLimitInterceptor) {
         this.rateLimitInterceptor = rateLimitInterceptor;
     }
 
     @Override
     public void addInterceptors(@NonNull InterceptorRegistry registry) {
-        // Register rate limit interceptor for all API endpoints (if available)
-        if (rateLimitInterceptor != null) {
-            registry.addInterceptor(rateLimitInterceptor)
-                    .addPathPatterns("/api/**");
-        }
+        registry.addInterceptor(rateLimitInterceptor)
+                .addPathPatterns("/api/**");
     }
 }

--- a/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java
@@ -314,7 +314,7 @@ public class GmailRepositoryImpl implements GmailRepository {
         try {
             Gmail gmail = getGmailService();
             Message message = gmail.users().messages().get(userId, messageId).execute();
-            logger.info("Message retrieved: {}", message.toPrettyString());
+            logger.info("Message retrieved: messageId={}", message.getId());
             return getMessageBodyFromParts(message.getPayload().getParts()); // Call helper function
 
         } catch (GeneralSecurityException e) {

--- a/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplTest.java
@@ -1,5 +1,9 @@
 package com.aucontraire.gmailbuddy.repository;
 
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
 import com.aucontraire.gmailbuddy.client.GmailClient;
 import com.aucontraire.gmailbuddy.client.GmailBatchClient;
 import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
@@ -10,6 +14,9 @@ import com.aucontraire.gmailbuddy.service.BulkOperationResult;
 import com.google.api.services.gmail.Gmail;
 import com.google.api.services.gmail.model.ListMessagesResponse;
 import com.google.api.services.gmail.model.Message;
+import com.google.api.services.gmail.model.MessagePart;
+import com.google.api.services.gmail.model.MessagePartBody;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,6 +25,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.security.GeneralSecurityException;
@@ -33,7 +41,7 @@ import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for GmailRepositoryImpl with TokenProvider abstraction.
- * 
+ *
  * These tests verify that the repository layer properly uses the TokenProvider
  * abstraction and is decoupled from Spring Security's SecurityContextHolder.
  */
@@ -57,34 +65,52 @@ class GmailRepositoryImplTest {
 
     @Mock
     private Gmail gmail;
-    
+
     @Mock
     private Gmail.Users users;
-    
+
     @Mock
     private Gmail.Users.Messages messages;
-    
+
     @Mock
     private Gmail.Users.Messages.List messagesList;
-    
+
     @Mock
     private Gmail.Users.Messages.Trash messagesTrash;
-    
+
     @Mock
     private Gmail.Users.Messages.Delete messagesDelete;
-    
+
+    @Mock
+    private Gmail.Users.Messages.Get messagesGet;
+
     private GmailRepositoryImpl repository;
-    
+
+    private ListAppender<ILoggingEvent> logAppender;
+    private Logger repositoryLogger;
+
     private static final String TEST_USER_ID = "testuser@example.com";
     private static final String TEST_ACCESS_TOKEN = "test-access-token-123";
     private static final String TEST_MESSAGE_ID = "test-message-id";
     private static final String TEST_QUERY = "from:test@example.com";
-    
+
     @BeforeEach
     void setUp() {
         repository = new GmailRepositoryImpl(gmailClient, gmailBatchClient, tokenProvider, properties, gmailMessageMapper);
+
+        repositoryLogger = (Logger) LoggerFactory.getLogger(GmailRepositoryImpl.class);
+        repositoryLogger.setLevel(Level.DEBUG);
+        logAppender = new ListAppender<>();
+        logAppender.start();
+        repositoryLogger.addAppender(logAppender);
     }
-    
+
+    @AfterEach
+    void tearDown() {
+        repositoryLogger.detachAppender(logAppender);
+        logAppender.stop();
+    }
+
     @Test
     void getMessages_WithValidToken_ReturnsMessages() throws IOException, GeneralSecurityException, AuthenticationException {
         // Given
@@ -110,33 +136,33 @@ class GmailRepositoryImplTest {
         verify(tokenProvider).getAccessToken();
         verify(gmailClient).createGmailService(TEST_ACCESS_TOKEN);
     }
-    
+
     @Test
     void getMessages_WithAuthenticationException_ThrowsIllegalStateException() throws AuthenticationException, GeneralSecurityException {
         // Given
         when(tokenProvider.getAccessToken()).thenThrow(new AuthenticationException("Token expired"));
-        
+
         // When & Then
         IllegalStateException exception = assertThrows(
             IllegalStateException.class,
             () -> repository.getMessages(TEST_USER_ID)
         );
-        
+
         assertTrue(exception.getMessage().contains("Failed to authenticate with Gmail API"));
         assertTrue(exception.getCause() instanceof AuthenticationException);
         verify(tokenProvider).getAccessToken();
         verifyNoInteractions(gmailClient);
     }
-    
+
     @Test
     void getLatestMessages_WithValidToken_ReturnsLimitedMessages() throws IOException, GeneralSecurityException, AuthenticationException {
         // Given
         long maxResults = 10L;
         Message message = new Message().setId("latest-msg");
         List<Message> expectedMessages = Arrays.asList(message);
-        
+
         ListMessagesResponse response = new ListMessagesResponse().setMessages(expectedMessages);
-        
+
         when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
         when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
         when(gmail.users()).thenReturn(users);
@@ -144,24 +170,24 @@ class GmailRepositoryImplTest {
         when(messages.list(TEST_USER_ID)).thenReturn(messagesList);
         when(messagesList.setMaxResults(maxResults)).thenReturn(messagesList);
         when(messagesList.execute()).thenReturn(response);
-        
+
         // When
         List<Message> result = repository.getLatestMessages(TEST_USER_ID, maxResults);
-        
+
         // Then
         assertEquals(expectedMessages, result);
         verify(messagesList).setMaxResults(maxResults);
         verify(tokenProvider).getAccessToken();
     }
-    
+
     @Test
     void getMessagesByFilterCriteria_WithValidQuery_ReturnsFilteredMessages() throws IOException, GeneralSecurityException, AuthenticationException {
         // Given
         Message message = new Message().setId("filtered-msg");
         List<Message> expectedMessages = Arrays.asList(message);
-        
+
         ListMessagesResponse response = new ListMessagesResponse().setMessages(expectedMessages);
-        
+
         when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
         when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
         when(gmail.users()).thenReturn(users);
@@ -169,16 +195,16 @@ class GmailRepositoryImplTest {
         when(messages.list(TEST_USER_ID)).thenReturn(messagesList);
         when(messagesList.setQ(TEST_QUERY)).thenReturn(messagesList);
         when(messagesList.execute()).thenReturn(response);
-        
+
         // When
         List<Message> result = repository.getMessagesByFilterCriteria(TEST_USER_ID, TEST_QUERY);
-        
+
         // Then
         assertEquals(expectedMessages, result);
         verify(messagesList).setQ(TEST_QUERY);
         verify(tokenProvider).getAccessToken();
     }
-    
+
     @Test
     void deleteMessage_WithValidToken_DeletesMessage() throws IOException, GeneralSecurityException, AuthenticationException {
         // Given
@@ -198,14 +224,14 @@ class GmailRepositoryImplTest {
         verify(tokenProvider).getAccessToken();
         verify(gmailBatchClient).batchDeleteMessages(gmail, TEST_USER_ID, List.of(TEST_MESSAGE_ID));
     }
-    
+
     @Test
     void deleteMessage_WithGmailClientException_ThrowsIOException() throws IOException, GeneralSecurityException, AuthenticationException {
         // Given
         when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
         when(gmailClient.createGmailService(TEST_ACCESS_TOKEN))
             .thenThrow(new GeneralSecurityException("Gmail service creation failed"));
-        
+
         // When & Then
         IOException exception = assertThrows(
             IOException.class,
@@ -244,10 +270,10 @@ class GmailRepositoryImplTest {
     void testTokenProviderIntegration_NoSecurityContextHolderDependency() throws AuthenticationException {
         // This test verifies that the repository doesn't directly use SecurityContextHolder
         // and relies solely on the TokenProvider abstraction
-        
+
         // Given
         when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
-        
+
         // When
         assertDoesNotThrow(() -> {
             // The repository should be able to get tokens without any SecurityContext setup
@@ -255,11 +281,11 @@ class GmailRepositoryImplTest {
             String token = tokenProvider.getAccessToken();
             assertNotNull(token);
         });
-        
+
         // Then
         verify(tokenProvider).getAccessToken();
     }
-    
+
     @Test
     void testTokenProviderMockability() throws AuthenticationException {
         // This test demonstrates how easy it is to mock the TokenProvider
@@ -319,5 +345,50 @@ class GmailRepositoryImplTest {
         // Assert
         verify(tokenProvider).getAccessToken();
         verify(gmailBatchClient).batchDeleteMessages(gmail, TEST_USER_ID, List.of(TEST_MESSAGE_ID));
+    }
+
+    // ========== Tests for PII / Constitution VII compliance ==========
+
+    @Test
+    @DisplayName("getMessageBody log must contain messageId and must NOT contain message body payload (Constitution VII)")
+    void getMessageBody_LogMustNotContainBodyPayload_OnlyMessageId()
+            throws IOException, GeneralSecurityException, AuthenticationException {
+        // Arrange - build a Message with no payload parts so getMessageBodyFromParts
+        // returns "" immediately without touching the mimeType property chain.
+        // The absence of parts is sufficient to exercise the log line under test.
+        Message message = new Message()
+                .setId(TEST_MESSAGE_ID)
+                .setPayload(new com.google.api.services.gmail.model.MessagePart().setParts(null));
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.messages()).thenReturn(messages);
+        when(messages.get(TEST_USER_ID, TEST_MESSAGE_ID)).thenReturn(messagesGet);
+        when(messagesGet.execute()).thenReturn(message);
+
+        // Act
+        repository.getMessageBody(TEST_USER_ID, TEST_MESSAGE_ID);
+
+        // Assert - the "Message retrieved" log line must contain the messageId
+        // and must NOT contain body-payload keywords (Constitution VII)
+        List<String> logMessages = logAppender.list.stream()
+                .map(ILoggingEvent::getFormattedMessage)
+                .filter(m -> m.contains("Message retrieved"))
+                .toList();
+
+        assertThat(logMessages)
+                .as("Expected exactly one 'Message retrieved' log statement")
+                .hasSize(1);
+
+        String retrievedLog = logMessages.get(0);
+        assertThat(retrievedLog)
+                .as("Log must contain the messageId for correlation")
+                .contains("messageId=" + TEST_MESSAGE_ID);
+        assertThat(retrievedLog)
+                .as("Log must NOT contain 'toPrettyString' serialized payload fields (Constitution VII)")
+                .doesNotContain("payload")
+                .doesNotContain("\"parts\"")
+                .doesNotContain("\"body\"");
     }
 }


### PR DESCRIPTION
## Summary

Closes two pre-existing follow-ups filed during the send/draft feature review.

- **FU-004 (Constitution VII)** — `GmailRepositoryImpl.getMessageBody` logged `Message.toPrettyString()`, which serializes the full Gmail SDK `Message` including `payload.parts.body.data` (base64 of the actual email body). Every call to `GET /api/v1/gmail/messages/{messageId}/body` was logging the whole body. Replaced with `Message.getId()` — a `messageId=…` correlation identifier and nothing else. Adds a Logback `ListAppender`-based regression test that asserts the log emits `messageId=` and contains no `payload`/`parts`/`body` fragments.
- **FU-002** — `WebConfig` had `@Autowired(required = false)` on its sole constructor, triggering Spring's "Inconsistent constructor declaration" warning on every startup. Verified `RateLimitInterceptor` is unconditionally `@Component` (no `@ConditionalOnProperty` / `@Profile` / property gate), so the optionality was dead code. Dropped the annotation, the matching null-guard in `addInterceptors`, the unused import, and the "if available" Javadoc/inline-comment phrasing.
- **`docs/FOLLOW_UPS.md`** — marked both items resolved per the doc's own convention. Active backlog (`FU-001`, `FU-003`, `FU-005`, `FU-006`) stays at the top; `FU-002` and `FU-004` moved to a new `## Resolved` section at the bottom with strikethrough headings and PR reference.

## Test plan

- [x] Targeted: `./mvnw test -Dtest=GmailRepositoryImplTest` → 12 / 0 / 0 (12 pass, includes new regression test `getMessageBody_LogMustNotContainBodyPayload_OnlyMessageId`)
- [x] Full suite: `./mvnw test` → **1051 / 0 / 2** (the 2 skips are the `@Disabled` tests filed as `FU-005` — out of scope for this branch)
- [x] No `@Disabled` introduced anywhere in the diff
- [x] No production code touched outside `WebConfig.java` and the single line in `GmailRepositoryImpl.java`
- [x] Reviewer: confirm the FOLLOW_UPS.md `PR #11` references on GitHub render to this PR (this is PR #11 unless something else got created in the meantime — easy 1-line fix if not)