### PR TITLE
fix(test): re-enable 2 disabled GmailControllerTest cases by fixing broken test context

### DIFF
--- a/docs/FOLLOW_UPS.md
+++ b/docs/FOLLOW_UPS.md
@@ -51,31 +51,6 @@ Origin: `ValidationException.getHttpStatus()` returns 400 (used by all Bean Vali
 
 ---
 
-## FU-005 — Resolve the 2 `@Disabled` tests in `GmailControllerTest`
-
-**Surfaces as**: `GmailControllerTest.java` carries 2 test methods annotated `@Disabled("Legacy test - ...")`. They show up as skips on every test run (`Tests run: 3, Failures: 0, Errors: 0, Skipped: 2`).
-
-**Why it's a real concern**: CLAUDE.md § "Test Integrity Rules (ABSOLUTE - ZERO TOLERANCE)" explicitly forbids `@Disabled` to hide problems:
-> NEVER skip tests with `@Disabled` to hide problems - Address the root cause
-> The ONLY acceptable actions when tests fail:
->   1. Fix the code if it's wrong
->   2. Fix the test if it's wrong
->   3. Update the test if requirements changed
->   4. Ask the user for clarification if unclear
-
-The 2 `@Disabled` annotations are pre-existing, not introduced by the send/draft feature, but they're a standing CLAUDE.md violation that ships in every commit until they're either fixed or honestly removed.
-
-**Recommended fix**:
-1. Read `GmailControllerTest.java` to understand what the 2 disabled tests were originally trying to verify.
-2. For each: decide whether the test is fixable (the production code may have changed making the assertions stale → update the test), should be deleted (the behavior under test is no longer relevant → `git rm` the test method), or should escalate to a real bug report (the test is correct but the production code is broken → fix the production code).
-3. Whatever the path, the `@Disabled` annotation must go. CLAUDE.md doesn't allow it.
-
-**Recommended timing**: small focused PR after the send/draft feature merges. ~30-min effort once the original intent of each test is understood.
-
-**Owner (per CLAUDE.md)**: `testing-qa-agent` (test integrity is their domain).
-
----
-
 ## FU-006 — Decide tracking policy for `CLAUDE.md` and `docs/Gmail-Buddy-API.postman_collection.json`
 
 **Surfaces as**: both files are present in the working tree, are updated whenever the API surface changes (most recently in PR #9 by tasks T056 and T057), but are kept untracked per the established branch convention. They drift from production over time without ever being committed.
@@ -118,3 +93,7 @@ Dropped `@Autowired(required = false)` from the sole constructor and the matchin
 ### ~~FU-004~~ — `getMessageBody` log statement leaked message body content (resolved in PR #11)
 
 Replaced `message.toPrettyString()` with `message.getId()` on the `getMessageBody` log line, closing a Constitution VII violation (full Gmail SDK `Message` — including `payload.parts.body.data` — was being logged on every `GET /api/v1/gmail/messages/{id}/body` call). Added a Logback `ListAppender`-based regression test asserting the log emits `messageId=…` and no payload/parts/body fragments.
+
+### ~~FU-005~~ — 2 `@Disabled` tests in `GmailControllerTest` (resolved in PR #12)
+
+Re-enabled both tests by fixing the underlying broken `@SpringBootTest` context. Root cause was deeper than the disable rationales suggested: an inner `@Configuration` class was suppressing full-application-context scanning, so security/exception-handling/message-conversion didn't behave as in production. Switched to `@SpringBootTest(classes = GmailBuddyApplication.class)` + `@ActiveProfiles("test")`, removed the inner config, added `@MockitoBean GmailRepository`, added `jsonPath` assertions on the `MessageListResponse` envelope. Skip count dropped from 2 to 0; the third test in the class (`testGetMessageBody_ResourceNotFoundException`) was previously passing for the wrong reason (Spring's default 404 handler, not `GlobalExceptionHandler`) and now passes correctly.

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/GmailControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/GmailControllerTest.java
@@ -1,12 +1,12 @@
 package com.aucontraire.gmailbuddy.controller;
 
+import com.aucontraire.gmailbuddy.GmailBuddyApplication;
 import com.aucontraire.gmailbuddy.config.TestTokenProviderConfiguration;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaDTO;
 import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
+import com.aucontraire.gmailbuddy.repository.GmailRepository;
 import com.aucontraire.gmailbuddy.service.GmailService;
 import com.aucontraire.gmailbuddy.service.MessageListResult;
-import com.aucontraire.gmailbuddy.service.TestOAuth2AuthorizedClientService;
-import com.google.api.services.gmail.model.Message;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -14,35 +14,34 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.mockito.Mockito;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.OAuth2AccessToken;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
-import java.util.List;
 
-import static org.mockito.Mockito.when;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@SpringBootTest(classes = GmailBuddyApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @AutoConfigureMockMvc
+@ActiveProfiles("test")
 @Import(TestTokenProviderConfiguration.class)
 public class GmailControllerTest {
 
@@ -54,16 +53,8 @@ public class GmailControllerTest {
     @MockitoBean
     private GmailService gmailService;
 
-    @Autowired
-    private OAuth2AuthorizedClientService authorizedClientService;
-
-    @Configuration
-    static class TestConfig {
-        @Bean
-        public OAuth2AuthorizedClientService authorizedClientService() {
-            return new TestOAuth2AuthorizedClientService();
-        }
-    }
+    @MockitoBean
+    private GmailRepository gmailRepository;
 
     @BeforeEach
     public void setup() {
@@ -78,7 +69,6 @@ public class GmailControllerTest {
     }
 
     @Test
-    @org.junit.jupiter.api.Disabled("Legacy test - content type issue needs investigation")
     public void testListMessagesByFilterCriteria() throws Exception {
         String jsonPayload = "{\n" +
                 "  \"from\": \"jobalerts-noreply@linkedin.com\",\n" +
@@ -97,11 +87,13 @@ public class GmailControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(jsonPayload)
                         .with(csrf()))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.messages").isArray())
+                .andExpect(jsonPath("$.totalCount").value(0));
     }
 
     @Test
-    @org.junit.jupiter.api.Disabled("Legacy test - Jackson serialization issue with Google Message objects")
     public void testListMessages() throws Exception {
         MessageListResult mockListResult = new MessageListResult(Collections.emptyList(), null, 0);
         when(gmailService.listMessagesWithPagination(eq("me"), any(), anyInt())).thenReturn(mockListResult);
@@ -109,7 +101,10 @@ public class GmailControllerTest {
         mockMvc.perform(get("/api/v1/gmail/messages")
                         .accept(MediaType.APPLICATION_JSON)
                         .with(csrf()))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.messages").isArray())
+                .andExpect(jsonPath("$.totalCount").value(0));
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes **FU-005** — the last `@Disabled` test annotations in the project. After this PR, `./mvnw test` reports `Tests run: 1051, Failures: 0, Errors: 0, Skipped: 0` for the first time.

### Why the disables were stale

Both tests carried disable rationales that referenced Gmail SDK serialization issues:
- `testListMessagesByFilterCriteria` — *"Legacy test - content type issue needs investigation"*
- `testListMessages` — *"Legacy test - Jackson serialization issue with Google Message objects"*

These pre-existed **PR #7's** API-standardization work, which switched the controllers to return the `MessageListResponse` DTO instead of raw Gmail SDK `Message` objects. PR #7 fixed the underlying serialization problem but left the `@Disabled` annotations in place. Standing CLAUDE.md zero-tolerance violation since then.

### Why the fix was bigger than just removing `@Disabled`

The deeper root cause: the test file used a **minimal `@SpringBootTest` context** because an inner `@Configuration class TestConfig` was suppressing full-application-context scanning. That meant security, exception handling, and HTTP message conversion didn't behave as in production. Just removing `@Disabled` would have left the tests in a half-broken state.

A side discovery: the third test in the class (`testGetMessageBody_ResourceNotFoundException`) was previously passing **for the wrong reason** — Spring's default 404 "no handler found" matched the `.isNotFound()` assertion, instead of `GlobalExceptionHandler` actually firing on the `ResourceNotFoundException`. With the full context loaded, it now passes correctly.

### What changed

`src/test/java/.../controller/GmailControllerTest.java`:
- `@SpringBootTest(classes = GmailBuddyApplication.class)` — load full app context.
- `@ActiveProfiles("test")` — load test OAuth2 client credentials.
- Removed the inner `@Configuration class TestConfig` that was suppressing scan.
- Added `@MockitoBean GmailRepository` to satisfy the dependency graph.
- Removed both `@org.junit.jupiter.api.Disabled` annotations.
- Added `jsonPath` assertions on `$.messages` (array) and `$.totalCount` (== 0) so the tests validate the `MessageListResponse` envelope shape, not just HTTP 200.
- Cleaned up unused imports.

`docs/FOLLOW_UPS.md`:
- FU-005 moved from active backlog to the `## Resolved` section with strikethrough heading and `(resolved in PR #12)` reference.

### Why fix-and-re-enable instead of delete

Before going down the fix path, I checked whether equivalent coverage existed elsewhere. `ApiClientAuthenticationIntegrationTest` covers the same two endpoints under the **Bearer-token** auth path, but not under the **OAuth2 browser-session** path that `GmailControllerTest` exercises in `@BeforeEach` (`OAuth2AuthenticationToken` → `SecurityContextHolder`). Deleting these two tests would have lost the only happy-path coverage for the browser-session controller path. Plus none of the integration tests assert the `MessageListResponse` envelope shape via `jsonPath`. Fix beats delete here.

## Test plan

- [x] Targeted: `./mvnw test -Dtest=GmailControllerTest` → `Tests run: 3, Failures: 0, Errors: 0, Skipped: 0`
- [x] Full suite: `./mvnw test` → **`Tests run: 1051, Failures: 0, Errors: 0, Skipped: 0`** (was 1051 / 0 / 2)
- [x] No `@Disabled` introduced anywhere; `grep -rn "Disabled(" src/test/` returns nothing
- [x] No production code touched (`src/main/` untouched)
- [x] No tests deleted, moved, or excluded in build config (CLAUDE.md test-integrity zero-tolerance rule)
- [x] Reviewer: confirm the FOLLOW_UPS.md `PR #12` reference renders to this PR (this is PR #12 unless something else got created in the meantime — easy 1-line fix if not)