### PR TITLE
fix: route Gmail invalidArgument to 422 InvalidRecipientException

### DIFF
--- a/docs/FOLLOW_UPS.md
+++ b/docs/FOLLOW_UPS.md
@@ -31,26 +31,6 @@ Origin: `TokenReferenceService` / `AESEncryptionUtil` (added in the Token Securi
 
 ---
 
-## FU-003 — `ValidationException` returns HTTP 400 instead of 422
-
-**Surfaces as**: contract drift between `specs/001-send-draft-emails/contracts/api-endpoints.md` (Endpoint 1 error matrix says `400 invalidArgument` from Gmail → `/problems/invalid-recipient` → HTTP **422 Unprocessable Entity**) and the actual production response, which returns HTTP **400 Bad Request**.
-
-Origin: `ValidationException.getHttpStatus()` returns 400 (used by all Bean Validation failures). When the send-message Gmail-error mapping helper (`mapGmailSendError`) wraps a Gmail-side `invalidArgument` rejection into `ValidationException`, `GlobalExceptionHandler.handleValidationException` resolves the status to 400 — same as a generic input-validation failure. The contract intends 422 for the semantic-rejection-by-mailbox-provider case, distinguishable from 400 for malformed request input.
-
-**Why it's not blocking**: the response is still actionable for the calling service — the ProblemDetail `type` URI distinguishes `/problems/invalid-recipient` from `/problems/validation-error`, so a sophisticated client can branch correctly. But the HTTP status semantics don't match the contract.
-
-**Recommended fix**:
-- Add a new `InvalidRecipientException extends GmailBuddyClientException` with `getHttpStatus() = 422`.
-- Update `GmailRepositoryImpl.mapGmailSendError(...)` to throw `InvalidRecipientException` (instead of `ValidationException`) for the `invalidArgument` case from Gmail's send/draft endpoints.
-- Add a dedicated `@ExceptionHandler(InvalidRecipientException.class)` branch in `GlobalExceptionHandler` returning 422 + `/problems/invalid-recipient`.
-- Update the SendMessageControllerTest assertion to expect 422 (currently asserts 400 to match observed behavior).
-
-**Recommended timing**: small follow-up commit on the same branch IF you want the contract to match before merging. Otherwise a focused follow-up PR after merge — the test asserts current behavior so this isn't a regression.
-
-**Owner (per CLAUDE.md)**: `validation-error-handler` (exception hierarchy + GlobalExceptionHandler) with light coordination from `gmail-api-integration` (the mapGmailSendError helper).
-
----
-
 ## FU-006 — Decide tracking policy for `CLAUDE.md` and `docs/Gmail-Buddy-API.postman_collection.json`
 
 **Surfaces as**: both files are present in the working tree, are updated whenever the API surface changes (most recently in PR #9 by tasks T056 and T057), but are kept untracked per the established branch convention. They drift from production over time without ever being committed.
@@ -73,10 +53,33 @@ Origin: `ValidationException.getHttpStatus()` returns 400 (used by all Bean Vali
 
 ---
 
+## FU-007 — `messageTooLarge` in `mapGmailSendError` claims HTTP 413 but returns 400
+
+**Surfaces as**: Javadoc on `mapGmailSendError` (`GmailRepositoryImpl.java`, line describing the `messageTooLarge` case) documents `HTTP 413` as the intended outcome, but the implementation wraps the error in `new ValidationException(...)`, whose `getHttpStatus()` returns `HttpStatus.BAD_REQUEST.value()` (400). `GlobalExceptionHandler.handleValidationException` then routes it to `/problems/validation-error` at 400 — not 413.
+
+**Why it's not blocking**: A 413 vs 400 distinction is a quality-of-API issue, not a functional one. Clients can still identify the error from the `detail` field ("Message exceeds Gmail's maximum allowed size"). The Javadoc note "(HTTP 413 via `GlobalExceptionHandler`; may become a dedicated exception in v2)" was aspirational at the time of writing, not a committed contract.
+
+**Recommended fix**:
+- Create `MessageTooLargeException extends GmailBuddyClientException` with `getHttpStatus() = HttpStatus.PAYLOAD_TOO_LARGE.value()` (413) and `ERROR_CODE = "MESSAGE_TOO_LARGE"`.
+- Add `ProblemTypes.MESSAGE_TOO_LARGE = BASE_URI + "/message-too-large"`.
+- Update the `messageTooLarge` case in `mapGmailSendError` to throw `MessageTooLargeException`.
+- Add `@ExceptionHandler(MessageTooLargeException.class)` in `GlobalExceptionHandler` returning 413 + `/problems/message-too-large`.
+- Update `determineProblemType` to include `"MESSAGE_TOO_LARGE"`.
+- Update (or add) repository and controller tests that assert `messageTooLarge` → `MessageTooLargeException` and 413 status.
+- Update OpenAPI `@ApiResponse` on `sendMessage` and `createDraft` to list 413.
+
+**Pattern to follow**: identical to FU-003 (`InvalidRecipientException` / `INVALID_RECIPIENT` / `/problems/invalid-recipient`) — it was resolved in this branch as a template.
+
+**Recommended timing**: small follow-up PR on master after FU-003 merges. Keep this scoped to the single `messageTooLarge` case — same focused diff pattern as FU-003.
+
+**Owner (per CLAUDE.md)**: `validation-error-handler` (exception hierarchy + GlobalExceptionHandler).
+
+---
+
 ## How to use this doc
 
 - Add new entries as `FU-NNN` sequentially.
-- Each entry stays open until the corresponding fix lands; on completion, mark the heading as `~~FU-NNN~~ (resolved in <commit-sha>)` and move to the bottom of the file.
+- Each entry stays open until the corresponding fix lands; on completion, strike the heading as `~~FU-NNN~~ (resolved in PR #N)` and move to the `## Resolved` section at the bottom with a trimmed 1-line summary. Full diagnostic detail at the time of filing stays in git history.
 - Items here are intentionally NOT the same scope as feature spec backlogs (which live under `specs/`); these are cross-cutting nits / operational items / pre-existing tech debt observed during feature work.
 - Scope guideline: prefer FOLLOW_UPS for items that can ship in 1 focused PR. Larger-scope items (deferred features, multi-step initiatives) live in maintainer-side planning notes outside this repo.
 
@@ -97,3 +100,7 @@ Replaced `message.toPrettyString()` with `message.getId()` on the `getMessageBod
 ### ~~FU-005~~ — 2 `@Disabled` tests in `GmailControllerTest` (resolved in PR #12)
 
 Re-enabled both tests by fixing the underlying broken `@SpringBootTest` context. Root cause was deeper than the disable rationales suggested: an inner `@Configuration` class was suppressing full-application-context scanning, so security/exception-handling/message-conversion didn't behave as in production. Switched to `@SpringBootTest(classes = GmailBuddyApplication.class)` + `@ActiveProfiles("test")`, removed the inner config, added `@MockitoBean GmailRepository`, added `jsonPath` assertions on the `MessageListResponse` envelope. Skip count dropped from 2 to 0; the third test in the class (`testGetMessageBody_ResourceNotFoundException`) was previously passing for the wrong reason (Spring's default 404 handler, not `GlobalExceptionHandler`) and now passes correctly.
+
+### ~~FU-003~~ — `ValidationException` returned HTTP 400 instead of 422 for Gmail `invalidArgument` (resolved in PR #13)
+
+Created `InvalidRecipientException extends GmailBuddyClientException` (HTTP 422) and routed Gmail's `invalidArgument` rejection through it instead of `ValidationException`. Added dedicated `@ExceptionHandler(InvalidRecipientException.class)` returning 422 + `/problems/invalid-recipient` (`ProblemTypes.INVALID_RECIPIENT` was already defined and unused). Updated repository, controller-slice, and exception-class tests; added a new `sendDraft_invalidArgumentError_throwsInvalidRecipientException` test (path was previously untested). Closes contract drift documented in `mapGmailSendError`'s Javadoc since the send/draft feature shipped. Also surfaced `messageTooLarge`'s analogous 400-vs-413 drift, filed as FU-007.

--- a/src/main/java/com/aucontraire/gmailbuddy/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/exception/GlobalExceptionHandler.java
@@ -244,6 +244,42 @@ public class GlobalExceptionHandler {
     }
 
     /**
+     * Handles InvalidRecipientException (Gmail-side rejection of a recipient address or
+     * message field with reason='invalidArgument').
+     *
+     * <p>This is a <em>semantic</em> rejection by the upstream mailbox provider, not a
+     * structural Bean Validation failure. The distinction is important for clients:
+     * a {@code 422} here means the input was well-formed but Gmail's delivery layer
+     * refused it, whereas a {@code 400} from
+     * {@link #handleValidationException(ValidationException)} means the input itself
+     * was structurally invalid before it ever reached Gmail.</p>
+     *
+     * Maps to RFC 7807 ProblemDetail with 422 Unprocessable Entity status and
+     * problem type {@link com.aucontraire.gmailbuddy.constants.ProblemTypes#INVALID_RECIPIENT}.
+     */
+    @ExceptionHandler(InvalidRecipientException.class)
+    public ResponseEntity<ProblemDetail> handleInvalidRecipientException(InvalidRecipientException ex) {
+        String requestId = getRequestId();
+        HttpStatus status = HttpStatus.valueOf(ex.getHttpStatus());
+
+        ProblemDetail problem = ProblemDetail.builder()
+                .type(ProblemTypes.INVALID_RECIPIENT)
+                .title("Invalid Recipient")
+                .status(status.value())
+                .detail(ex.getMessage())
+                .instance(request.getRequestURI())
+                .requestId(requestId)
+                .retryable(false)
+                .category("CLIENT_ERROR")
+                .build();
+
+        logger.warn("Recipient rejected by Gmail [{}]: {} (correlation: {})",
+                ex.getErrorCode(), ex.getMessage(), requestId);
+
+        return buildProblemResponse(problem, status);
+    }
+
+    /**
      * Handles generic GmailBuddyException instances not caught by more specific handlers.
      */
     @ExceptionHandler(GmailBuddyException.class)
@@ -435,6 +471,7 @@ public class GlobalExceptionHandler {
     private String determineProblemType(String errorCode) {
         return switch (errorCode) {
             case "VALIDATION_ERROR" -> ProblemTypes.VALIDATION_ERROR;
+            case "INVALID_RECIPIENT" -> ProblemTypes.INVALID_RECIPIENT;
             case "RESOURCE_NOT_FOUND" -> ProblemTypes.RESOURCE_NOT_FOUND;
             case "AUTHENTICATION_ERROR" -> ProblemTypes.AUTHENTICATION_FAILED;
             case "AUTHORIZATION_ERROR" -> ProblemTypes.AUTHORIZATION_FAILED;

--- a/src/main/java/com/aucontraire/gmailbuddy/exception/InvalidRecipientException.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/exception/InvalidRecipientException.java
@@ -1,0 +1,70 @@
+package com.aucontraire.gmailbuddy.exception;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * Thrown when Gmail's send/draft API rejects a recipient address or message field
+ * with {@code reason='invalidArgument'}.
+ *
+ * <p>Distinguished from {@link ValidationException} (which covers Bean Validation
+ * failures on input) because this is a <em>semantic</em> rejection by the mailbox
+ * provider, not a structural rejection of input. The caller supplied a
+ * syntactically plausible address that passed all local Bean Validation rules, but
+ * Gmail's upstream delivery layer determined the address cannot receive mail
+ * (e.g., the mailbox does not exist, is over quota, or the domain rejects the
+ * message).</p>
+ *
+ * <p>Maps to HTTP {@code 422 Unprocessable Entity} and problem type
+ * {@code /problems/invalid-recipient}.</p>
+ *
+ * @see ValidationException
+ * @see com.aucontraire.gmailbuddy.constants.ProblemTypes#INVALID_RECIPIENT
+ */
+public class InvalidRecipientException extends GmailBuddyClientException {
+
+    private static final String ERROR_CODE = "INVALID_RECIPIENT";
+
+    /**
+     * Constructs a new invalid-recipient exception with the specified message.
+     *
+     * @param message the detail message explaining the Gmail rejection
+     */
+    public InvalidRecipientException(String message) {
+        super(ERROR_CODE, message);
+    }
+
+    /**
+     * Constructs a new invalid-recipient exception with the specified message and cause.
+     *
+     * @param message the detail message explaining the Gmail rejection
+     * @param cause   the underlying {@link com.google.api.client.googleapis.json.GoogleJsonResponseException}
+     *                returned by the Gmail API client
+     */
+    public InvalidRecipientException(String message, Throwable cause) {
+        super(ERROR_CODE, message, cause);
+    }
+
+    /**
+     * Constructs a new invalid-recipient exception with the specified message and correlation ID.
+     *
+     * @param message       the detail message explaining the Gmail rejection
+     * @param correlationId the correlation ID for request tracing
+     */
+    public InvalidRecipientException(String message, String correlationId) {
+        super(ERROR_CODE, message, correlationId);
+    }
+
+    /**
+     * Returns {@code 422 Unprocessable Entity}.
+     *
+     * <p>The request was well-formed (passed Bean Validation) but could not be
+     * processed by Gmail because a recipient address or message field was semantically
+     * invalid from the mailbox provider's perspective.</p>
+     *
+     * @return {@link HttpStatus#UNPROCESSABLE_ENTITY} value (422)
+     */
+    @Override
+    public int getHttpStatus() {
+        return HttpStatus.UNPROCESSABLE_ENTITY.value();
+    }
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java
@@ -5,6 +5,7 @@ import com.aucontraire.gmailbuddy.client.GmailBatchClient;
 import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
 import com.aucontraire.gmailbuddy.exception.AuthenticationException;
 import com.aucontraire.gmailbuddy.exception.AuthorizationException;
+import com.aucontraire.gmailbuddy.exception.InvalidRecipientException;
 import com.aucontraire.gmailbuddy.exception.MessageSendException;
 import com.aucontraire.gmailbuddy.exception.RateLimitException;
 import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
@@ -534,7 +535,7 @@ public class GmailRepositoryImpl implements GmailRepository {
      * The mapping follows research.md Decision 10:</p>
      *
      * <ul>
-     *   <li>{@code invalidArgument} → {@link ValidationException} (HTTP 422)</li>
+     *   <li>{@code invalidArgument} → {@link InvalidRecipientException} (HTTP 422)</li>
      *   <li>{@code insufficientPermissions} → {@link AuthorizationException} (HTTP 403)</li>
      *   <li>{@code dailySendLimitExceeded} → {@link RateLimitException}
      *       with {@code retryAfterSeconds=86400} (HTTP 429).
@@ -576,7 +577,7 @@ public class GmailRepositoryImpl implements GmailRepository {
 
         return switch (reason) {
             case "invalidArgument" ->
-                    new ValidationException(
+                    new InvalidRecipientException(
                             "Gmail rejected one or more recipient addresses or message fields", e);
 
             case "insufficientPermissions" ->

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/SendMessageControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/SendMessageControllerTest.java
@@ -1,7 +1,7 @@
 package com.aucontraire.gmailbuddy.controller;
 
 import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
-import com.aucontraire.gmailbuddy.exception.ValidationException;
+import com.aucontraire.gmailbuddy.exception.InvalidRecipientException;
 import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
 import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
@@ -41,8 +41,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  *   <li>Location header IS present and ends with {@code /body} per Decision 3 and
  *       contracts/api-endpoints.md Endpoint 1</li>
  *   <li>Response body: {@code {messageId, threadId, status: "SENT"}}</li>
- *   <li>Validation failure (Gmail rejects recipient) → service throws
- *       {@link ValidationException} → 400 with problem type</li>
+ *   <li>Recipient rejection (Gmail rejects recipient) → service throws
+ *       {@link InvalidRecipientException} → 422 with problem type
+ *       {@code /problems/invalid-recipient}</li>
  * </ul>
  *
  * <p>Uses {@code @WebMvcTest} (web layer only) with {@code @MockitoBean GmailService}.
@@ -192,26 +193,25 @@ class SendMessageControllerTest {
     }
 
     // -------------------------------------------------------------------------
-    // 400 — Gmail rejects the recipient (ValidationException from service layer)
+    // 422 — Gmail rejects the recipient (InvalidRecipientException from service layer)
     // -------------------------------------------------------------------------
 
     @Test
     @WithMockUser
-    @DisplayName("postSendMessage_gmailRejectsRecipient_returns400WithValidationErrorProblemType")
-    void postSendMessage_gmailRejectsRecipient_returns400WithValidationErrorProblemType()
+    @DisplayName("postSendMessage_gmailRejectsRecipient_returns422WithInvalidRecipientProblemType")
+    void postSendMessage_gmailRejectsRecipient_returns422WithInvalidRecipientProblemType()
             throws Exception {
-        // Arrange: service throws ValidationException when Gmail returns 400 invalidArgument
-        // (mapped from mapGmailSendError in the repository layer and wrapped in GmailApiException
-        // at the service layer — but since ValidationException is a RuntimeException it propagates
-        // directly through the GmailApiException catch-block only for IOException).
-        // The repository throws ValidationException directly (it's a RuntimeException),
-        // which the service does NOT catch (only IOException is caught).
-        // GlobalExceptionHandler catches ValidationException → 400 + /problems/validation-error.
+        // Arrange: the repository maps Gmail's 400 invalidArgument reason to
+        // InvalidRecipientException (not ValidationException), which propagates as a
+        // RuntimeException through the service layer uncaught (only IOException is caught).
+        // GlobalExceptionHandler.handleInvalidRecipientException catches it and returns
+        // 422 Unprocessable Entity + /problems/invalid-recipient, distinguishing a
+        // mailbox-provider semantic rejection from a Bean Validation structural failure (400).
         SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
         String requestBody = objectMapper.writeValueAsString(dto);
 
         when(gmailService.sendMessage(eq("me"), any(SendMessageDTO.class)))
-                .thenThrow(new ValidationException(
+                .thenThrow(new InvalidRecipientException(
                         "Gmail rejected one or more recipient addresses or message fields"));
 
         // Act & Assert
@@ -219,8 +219,8 @@ class SendMessageControllerTest {
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(requestBody))
-                .andExpect(status().isBadRequest())
-                .andExpect(jsonPath("$.type").value("/problems/validation-error"));
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.type").value("/problems/invalid-recipient"));
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/aucontraire/gmailbuddy/exception/InvalidRecipientExceptionTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/exception/InvalidRecipientExceptionTest.java
@@ -1,0 +1,143 @@
+package com.aucontraire.gmailbuddy.exception;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link InvalidRecipientException}.
+ *
+ * <p>Validates that all three constructor variants initialise the error code,
+ * message, correlation ID, and cause correctly, and that {@link
+ * InvalidRecipientException#getHttpStatus()} always returns 422.</p>
+ *
+ * <p>Mirrors the structure of {@link MessageSendExceptionTest}.</p>
+ */
+@DisplayName("InvalidRecipientException Tests")
+class InvalidRecipientExceptionTest {
+
+    // ---------------------------------------------------------------
+    // Constructor: InvalidRecipientException(String message)
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("Constructor with message initialises error code, message, and correlation ID")
+    void constructor_WithMessageOnly_ShouldInitialiseFields() {
+        // Arrange
+        String message = "Gmail rejected one or more recipient addresses or message fields";
+
+        // Act
+        InvalidRecipientException exception = new InvalidRecipientException(message);
+
+        // Assert
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getErrorCode()).isEqualTo("INVALID_RECIPIENT");
+        assertThat(exception.getCorrelationId()).isNotNull().isNotEmpty();
+        assertThat(exception.getCause()).isNull();
+    }
+
+    // ---------------------------------------------------------------
+    // Constructor: InvalidRecipientException(String message, Throwable cause)
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("Constructor with message and cause preserves the upstream cause")
+    void constructor_WithMessageAndCause_ShouldPreserveCause() {
+        // Arrange
+        String message = "Gmail rejected recipient: no such mailbox";
+        Throwable cause = new RuntimeException("googleJsonResponseException mock");
+
+        // Act
+        InvalidRecipientException exception = new InvalidRecipientException(message, cause);
+
+        // Assert
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getErrorCode()).isEqualTo("INVALID_RECIPIENT");
+        assertThat(exception.getCause()).isSameAs(cause);
+        assertThat(exception.getCorrelationId()).isNotNull().isNotEmpty();
+    }
+
+    // ---------------------------------------------------------------
+    // Constructor: InvalidRecipientException(String message, String correlationId)
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("Constructor with message and correlationId stores the supplied correlation ID")
+    void constructor_WithMessageAndCorrelationId_ShouldStoreCorrelationId() {
+        // Arrange
+        String message = "Gmail rejected recipient for traced request";
+        String correlationId = "trace-xyz-999";
+
+        // Act
+        InvalidRecipientException exception = new InvalidRecipientException(message, correlationId);
+
+        // Assert
+        assertThat(exception.getMessage()).isEqualTo(message);
+        assertThat(exception.getErrorCode()).isEqualTo("INVALID_RECIPIENT");
+        assertThat(exception.getCorrelationId()).isEqualTo(correlationId);
+        assertThat(exception.getCause()).isNull();
+    }
+
+    // ---------------------------------------------------------------
+    // getHttpStatus()
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("getHttpStatus returns 422 Unprocessable Entity for all constructor variants")
+    void getHttpStatus_Always_Returns422UnprocessableEntity() {
+        // Arrange
+        InvalidRecipientException fromMessage =
+                new InvalidRecipientException("recipient rejected");
+        InvalidRecipientException fromMessageAndCause =
+                new InvalidRecipientException("recipient rejected", new Exception("api error"));
+        InvalidRecipientException fromMessageAndCorrelation =
+                new InvalidRecipientException("recipient rejected", "corr-id-001");
+
+        // Act & Assert: all three constructors must resolve to 422, not 400.
+        assertThat(fromMessage.getHttpStatus())
+                .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
+        assertThat(fromMessageAndCause.getHttpStatus())
+                .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
+        assertThat(fromMessageAndCorrelation.getHttpStatus())
+                .isEqualTo(HttpStatus.UNPROCESSABLE_ENTITY.value());
+    }
+
+    // ---------------------------------------------------------------
+    // isClientError() — inherited final method from GmailBuddyClientException
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("isClientError returns true because the rejection is a client-addressable condition")
+    void isClientError_Always_ReturnsTrue() {
+        // Arrange
+        InvalidRecipientException exception =
+                new InvalidRecipientException("Gmail rejected recipient");
+
+        // Act
+        boolean clientError = exception.isClientError();
+
+        // Assert: the caller can fix this by correcting the recipient address.
+        assertThat(clientError).isTrue();
+    }
+
+    // ---------------------------------------------------------------
+    // Inheritance — must extend GmailBuddyClientException (not ValidationException)
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("InvalidRecipientException extends GmailBuddyClientException, not ValidationException")
+    void classhierarchy_ExtendsClientExceptionNotValidationException() {
+        // Arrange
+        InvalidRecipientException exception =
+                new InvalidRecipientException("recipient rejected");
+
+        // Assert: extends the client base, not ValidationException, so that
+        // GlobalExceptionHandler.handleValidationException does NOT catch it.
+        assertThat(exception).isInstanceOf(GmailBuddyClientException.class);
+        assertThat(exception).isInstanceOf(GmailBuddyException.class);
+        assertThat(exception).isInstanceOf(RuntimeException.class);
+        assertThat(exception).isNotInstanceOf(ValidationException.class);
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplCreateDraftTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplCreateDraftTest.java
@@ -3,8 +3,8 @@ package com.aucontraire.gmailbuddy.repository;
 import com.aucontraire.gmailbuddy.client.GmailBatchClient;
 import com.aucontraire.gmailbuddy.client.GmailClient;
 import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
+import com.aucontraire.gmailbuddy.exception.InvalidRecipientException;
 import com.aucontraire.gmailbuddy.exception.RateLimitException;
-import com.aucontraire.gmailbuddy.exception.ValidationException;
 import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.service.DraftCreationResult;
 import com.aucontraire.gmailbuddy.service.TokenProvider;
@@ -240,12 +240,12 @@ class GmailRepositoryImplCreateDraftTest {
     }
 
     // -------------------------------------------------------------------------
-    // GoogleJsonResponseException — invalidArgument → ValidationException
+    // GoogleJsonResponseException — invalidArgument → InvalidRecipientException
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("createDraft_invalidArgumentError_throwsValidationException")
-    void createDraft_invalidArgumentError_throwsValidationException() throws Exception {
+    @DisplayName("createDraft_invalidArgumentError_throwsInvalidRecipientException")
+    void createDraft_invalidArgumentError_throwsInvalidRecipientException() throws Exception {
         // Arrange
         MimeMessage mimeMessage = buildTestMimeMessage();
         GoogleJsonResponseException gmailError =
@@ -258,9 +258,10 @@ class GmailRepositoryImplCreateDraftTest {
         when(drafts.create(eq(TEST_USER_ID), any(Draft.class))).thenReturn(draftsCreate);
         when(draftsCreate.execute()).thenThrow(gmailError);
 
-        // Act & Assert
+        // Act & Assert: Gmail's semantic rejection of a recipient maps to
+        // InvalidRecipientException (HTTP 422), not ValidationException (HTTP 400).
         assertThatThrownBy(() -> repository.createDraft(TEST_USER_ID, mimeMessage))
-                .isInstanceOf(ValidationException.class);
+                .isInstanceOf(InvalidRecipientException.class);
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplSendDraftTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplSendDraftTest.java
@@ -3,6 +3,7 @@ package com.aucontraire.gmailbuddy.repository;
 import com.aucontraire.gmailbuddy.client.GmailBatchClient;
 import com.aucontraire.gmailbuddy.client.GmailClient;
 import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
+import com.aucontraire.gmailbuddy.exception.InvalidRecipientException;
 import com.aucontraire.gmailbuddy.exception.RateLimitException;
 import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
 import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
@@ -223,6 +224,30 @@ class GmailRepositoryImplSendDraftTest {
                     RateLimitException rle = (RateLimitException) ex;
                     assertThat(rle.getRetryAfterSeconds()).isEqualTo(86400L);
                 });
+    }
+
+    // -------------------------------------------------------------------------
+    // GoogleJsonResponseException — invalidArgument → InvalidRecipientException
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("sendDraft_invalidArgumentError_throwsInvalidRecipientException")
+    void sendDraft_invalidArgumentError_throwsInvalidRecipientException() throws Exception {
+        // Arrange: Gmail rejects the draft recipient with 400 invalidArgument.
+        GoogleJsonResponseException gmailError =
+                buildGoogleJsonException(400, "invalidArgument");
+
+        when(tokenProvider.getAccessToken()).thenReturn(TEST_ACCESS_TOKEN);
+        when(gmailClient.createGmailService(TEST_ACCESS_TOKEN)).thenReturn(gmail);
+        when(gmail.users()).thenReturn(users);
+        when(users.drafts()).thenReturn(drafts);
+        when(drafts.send(eq(TEST_USER_ID), any(Draft.class))).thenReturn(draftsSend);
+        when(draftsSend.execute()).thenThrow(gmailError);
+
+        // Act & Assert: Gmail's semantic rejection of a recipient maps to
+        // InvalidRecipientException (HTTP 422), not ValidationException (HTTP 400).
+        assertThatThrownBy(() -> repository.sendDraft(TEST_USER_ID, TEST_DRAFT_ID))
+                .isInstanceOf(InvalidRecipientException.class);
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplSendMessageTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImplSendMessageTest.java
@@ -4,6 +4,7 @@ import com.aucontraire.gmailbuddy.client.GmailBatchClient;
 import com.aucontraire.gmailbuddy.client.GmailClient;
 import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
 import com.aucontraire.gmailbuddy.exception.AuthorizationException;
+import com.aucontraire.gmailbuddy.exception.InvalidRecipientException;
 import com.aucontraire.gmailbuddy.exception.RateLimitException;
 import com.aucontraire.gmailbuddy.exception.ValidationException;
 import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
@@ -234,12 +235,12 @@ class GmailRepositoryImplSendMessageTest {
     }
 
     // -------------------------------------------------------------------------
-    // GoogleJsonResponseException — invalidArgument → ValidationException
+    // GoogleJsonResponseException — invalidArgument → InvalidRecipientException
     // -------------------------------------------------------------------------
 
     @Test
-    @DisplayName("sendMessage_invalidArgumentError_throwsValidationException")
-    void sendMessage_invalidArgumentError_throwsValidationException() throws Exception {
+    @DisplayName("sendMessage_invalidArgumentError_throwsInvalidRecipientException")
+    void sendMessage_invalidArgumentError_throwsInvalidRecipientException() throws Exception {
         // Arrange: Gmail rejects the recipient with 400 invalidArgument.
         MimeMessage mimeMessage = buildTestMimeMessage();
         GoogleJsonResponseException gmailError =
@@ -252,9 +253,10 @@ class GmailRepositoryImplSendMessageTest {
         when(messages.send(eq(TEST_USER_ID), any(Message.class))).thenReturn(messagesSend);
         when(messagesSend.execute()).thenThrow(gmailError);
 
-        // Act & Assert
+        // Act & Assert: Gmail's semantic rejection of a recipient maps to
+        // InvalidRecipientException (HTTP 422), not ValidationException (HTTP 400).
         assertThatThrownBy(() -> repository.sendMessage(TEST_USER_ID, mimeMessage))
-                .isInstanceOf(ValidationException.class);
+                .isInstanceOf(InvalidRecipientException.class);
     }
 
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes **FU-003** — contract drift between `mapGmailSendError`'s Javadoc (claims `invalidArgument → ValidationException (HTTP 422)`) and the actual production response (`HTTP 400 /problems/validation-error`, indistinguishable from a Bean Validation failure on input).

The contract in `specs/001-send-draft-emails/contracts/api-endpoints.md` (Endpoint 1 error matrix) calls for **`422 /problems/invalid-recipient`** for the Gmail-side semantic-rejection-by-mailbox-provider case. Already half-wired before this PR: `ProblemTypes.INVALID_RECIPIENT` was defined at line 98 of `ProblemTypes.java` but never referenced.

### What changed

**Production**:
- New `InvalidRecipientException extends GmailBuddyClientException` (HTTP 422, `ERROR_CODE = "INVALID_RECIPIENT"`). Distinct from `ValidationException` so handlers don't share the wrong type-resolution branch.
- `GmailRepositoryImpl.mapGmailSendError` `invalidArgument` branch now throws `InvalidRecipientException`. Javadoc updated.
- `GlobalExceptionHandler.handleInvalidRecipientException` returns `422 + /problems/invalid-recipient`. Log message identifies the rejection as mailbox-provider-side, not input validation.
- `determineProblemType` updated to recognize `"INVALID_RECIPIENT"`.

**Tests**:
- New `InvalidRecipientExceptionTest` (6 tests) gives the new class 100% coverage. Includes a `not instanceof ValidationException` assertion to lock in the type-distinction.
- Repository tests in `GmailRepositoryImplCreateDraftTest` and `GmailRepositoryImplSendMessageTest` renamed and updated for the new exception type.
- `GmailRepositoryImplSendDraftTest` gained a brand-new test (`sendDraft_invalidArgumentError_throwsInvalidRecipientException`) — the `sendDraft` path was previously **untested** for this case despite using the same `mapGmailSendError` helper. Closes a coverage gap.
- `SendMessageControllerTest.postSendMessage_gmailRejectsRecipient_returns400WithValidationErrorProblemType` renamed to `...returns422WithInvalidRecipientProblemType`; assertion updated to `.isUnprocessableEntity()` + `/problems/invalid-recipient`.

**Docs**:
- `FU-003` → Resolved (this PR).
- `FU-007` filed: surfaces an analogous drift in `mapGmailSendError`'s `messageTooLarge` branch (Javadoc claims HTTP 413, implementation returns 400 via `ValidationException`). Recommended fix follows the FU-003 pattern exactly. Out of scope for this PR.
- "How to use this doc" updated to reflect the actual convention (PR # not commit SHA, move to `## Resolved` section with trimmed 1-line summary).

### Why distinct exception, not just bumping ValidationException to 422

`ValidationException` is the type Bean Validation failures use (malformed input on the way in) and correctly returns 400. The Gmail-side `invalidArgument` rejection is structurally different: the input was well-formed and passed all local validation, but the upstream mailbox provider rejected the recipient address (e.g., mailbox doesn't exist, domain rejects). 422 Unprocessable Entity is the correct semantic for that — well-formed but un-processable. Keeping the two exception types distinct also lets log triage and metrics distinguish "client sent bad input" from "Gmail rejected our recipient."

### Why `sendDraft` got a new test instead of just an updated one

The send-draft path also calls `mapGmailSendError`, so it can throw `InvalidRecipientException`. Before this PR, `GmailRepositoryImplSendDraftTest` had no `invalidArgument`-flow test at all. Adding it now closes a pre-existing coverage gap surfaced by the FU-003 work.

## Test plan

- [x] `./mvnw test -Dtest=InvalidRecipientExceptionTest` → 6 / 0 / 0
- [x] `./mvnw test -Dtest='GmailRepositoryImpl*Test'` → all repository tests green including the renamed and new `invalidArgument` cases
- [x] `./mvnw test -Dtest=SendMessageControllerTest` → renamed test passes with 422 assertion
- [x] Full suite: `./mvnw test` → **`Tests run: 1058, Failures: 0, Errors: 0, Skipped: 0`** (was 1051 / 0 / 0; +7 from new tests)
- [x] No `@Disabled` introduced anywhere
- [x] `messageTooLarge` left unchanged (out of scope per FU-007)
- [x] OpenAPI `@ApiResponse` 422 already listed for `createDraft` and `sendMessage`; verified no doc drift introduced. `sendDraft`'s `@ApiResponses` does not list 422 — flagged as part of FU-007's recommended fix scope (since FU-007 covers the same `mapGmailSendError`-touches-three-endpoints pattern)
- [x] Reviewer: confirm the `FU-003 → resolved in PR #13` reference renders to this PR (predicted #13; easy 1-line fix if not)