### PR TITLE
feat: drafts CRUD endpoints (list, get, delete, update) (003)

### DIFF
--- a/docs/Gmail-Buddy-API.postman_collection.json
+++ b/docs/Gmail-Buddy-API.postman_collection.json
@@ -983,9 +983,855 @@
 							"body": "{\n    \"messageId\": \"19a2b3c4d5e6f7ga\",\n    \"threadId\": \"1976a4bc3fe89d0c\",\n    \"status\": \"SENT\"\n}"
 						}
 					]
+				},
+				{
+					"name": "List Drafts",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/v1/gmail/drafts?limit=25",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"gmail",
+								"drafts"
+							],
+							"query": [
+								{
+									"key": "limit",
+									"value": "25",
+									"description": "Items per page. Min 1, max 50. Default 25."
+								},
+								{
+									"key": "pageToken",
+									"value": "",
+									"description": "Opaque pagination token from a prior response's nextPageToken. Omit for the first page.",
+									"disabled": true
+								}
+							]
+						},
+						"description": "Returns a paginated list of pending drafts for the authenticated user. Each item in `results` is a DraftListItem summary (id, recipients, subject, snippet, threadId, attachmentCount). Use `nextPageToken` to fetch subsequent pages. An empty Drafts folder returns HTTP 200 with an empty `results` array — not 404.\n\nQuota cost: 1 unit (list call) + N×5 units (per-item get calls). For a full page of 25 items: 126 units.\n\nFeature 003 (drafts-crud). Requires gmail.modify scope (already in the project scope set)."
+					},
+					"response": [
+						{
+							"name": "200 OK — Drafts listed successfully",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts?limit=25",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "25"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "X-Gmail-Quota-Used",
+									"value": "11"
+								},
+								{
+									"key": "X-RateLimit-Limit",
+									"value": "250"
+								},
+								{
+									"key": "X-RateLimit-Remaining",
+									"value": "239"
+								},
+								{
+									"key": "X-RateLimit-Reset",
+									"value": "1746835200"
+								}
+							],
+							"body": "{\n    \"results\": [\n        {\n            \"id\": \"1a2b3c4d5e6f7890\",\n            \"to\": [\"hiring-manager@bigcorp.example\"],\n            \"cc\": [],\n            \"bcc\": [],\n            \"subject\": \"Following up \\u2014 Senior Backend Engineer application\",\n            \"snippet\": \"Hi, I wanted to follow up on my application...\",\n            \"threadId\": \"1976a4bc3fe89d0c\",\n            \"attachmentCount\": 1\n        },\n        {\n            \"id\": \"2b3c4d5e6f789012\",\n            \"to\": [\"recruiter@startupco.example\"],\n            \"cc\": [],\n            \"bcc\": [],\n            \"subject\": \"Introduction \\u2014 Backend Engineer\",\n            \"snippet\": \"Hi Sarah, I saw your posting on LinkedIn...\",\n            \"threadId\": null,\n            \"attachmentCount\": 0\n        }\n    ],\n    \"nextPageToken\": \"eyJwYWdlVG9rZW4i...\",\n    \"totalCount\": 15\n}"
+						},
+						{
+							"name": "200 OK — Empty drafts queue",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts?limit=25",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "25"
+										}
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "X-Gmail-Quota-Used",
+									"value": "1"
+								},
+								{
+									"key": "X-RateLimit-Limit",
+									"value": "250"
+								},
+								{
+									"key": "X-RateLimit-Remaining",
+									"value": "249"
+								},
+								{
+									"key": "X-RateLimit-Reset",
+									"value": "1746835200"
+								}
+							],
+							"body": "{\n    \"results\": [],\n    \"nextPageToken\": null,\n    \"totalCount\": 0\n}"
+						},
+						{
+							"name": "400 Bad Request — Invalid limit parameter",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts?limit=99",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts"
+									],
+									"query": [
+										{
+											"key": "limit",
+											"value": "99"
+										}
+									]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/problem+json"
+								}
+							],
+							"body": "{\n    \"type\": \"/problems/validation-error\",\n    \"title\": \"Validation Error\",\n    \"status\": 400,\n    \"detail\": \"Request validation failed\",\n    \"instance\": \"/api/v1/gmail/drafts\",\n    \"extensions\": {\n        \"constraint:listDrafts.limit\": \"must be less than or equal to 50\"\n    }\n}"
+						}
+					]
+				},
+				{
+					"name": "Get Draft Detail",
+					"request": {
+						"method": "GET",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/v1/gmail/drafts/:draftId",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"gmail",
+								"drafts",
+								":draftId"
+							],
+							"variable": [
+								{
+									"key": "draftId",
+									"value": "1a2b3c4d5e6f7890",
+									"description": "Gmail draft ID. Must match [0-9a-fA-F]{1,32}. Obtain from the id field in List Drafts response."
+								}
+							]
+						},
+						"description": "Retrieves the full content of a single draft including body text, all recipients, threading metadata (threadId, inReplyToMessageId), and attachment metadata (filename, mimeType, sizeBytes — binary data is NOT returned). Use this endpoint after List Drafts to inspect a specific draft before sending, updating, or deleting it.\n\nQuota cost: 5 units per call (users.drafts.get with format=FULL).\n\nFeature 003 (drafts-crud). Requires gmail.modify scope."
+					},
+					"response": [
+						{
+							"name": "200 OK — Full draft detail with attachment",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/1a2b3c4d5e6f7890",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"1a2b3c4d5e6f7890"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "X-Gmail-Quota-Used",
+									"value": "5"
+								},
+								{
+									"key": "X-RateLimit-Limit",
+									"value": "250"
+								},
+								{
+									"key": "X-RateLimit-Remaining",
+									"value": "245"
+								},
+								{
+									"key": "X-RateLimit-Reset",
+									"value": "1746835200"
+								}
+							],
+							"body": "{\n    \"id\": \"1a2b3c4d5e6f7890\",\n    \"to\": [\"hiring-manager@bigcorp.example\"],\n    \"cc\": [],\n    \"bcc\": [],\n    \"subject\": \"Following up \\u2014 Senior Backend Engineer application\",\n    \"body\": \"<p>Hi,</p><p>I wanted to follow up on my application for the Senior Backend Engineer role.</p>\",\n    \"bodyType\": \"html\",\n    \"threadId\": \"1976a4bc3fe89d0c\",\n    \"inReplyToMessageId\": \"1976a4bc3fe89d0c\",\n    \"attachments\": [\n        {\n            \"filename\": \"resume-2026.pdf\",\n            \"mimeType\": \"application/pdf\",\n            \"sizeBytes\": 245760\n        }\n    ]\n}"
+						},
+						{
+							"name": "200 OK — Plain draft (no threading, no attachments)",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/2b3c4d5e6f789012",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"2b3c4d5e6f789012"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "X-Gmail-Quota-Used",
+									"value": "5"
+								},
+								{
+									"key": "X-RateLimit-Limit",
+									"value": "250"
+								},
+								{
+									"key": "X-RateLimit-Remaining",
+									"value": "245"
+								},
+								{
+									"key": "X-RateLimit-Reset",
+									"value": "1746835200"
+								}
+							],
+							"body": "{\n    \"id\": \"2b3c4d5e6f789012\",\n    \"to\": [\"recruiter@startupco.example\"],\n    \"cc\": [],\n    \"bcc\": [],\n    \"subject\": \"Introduction \\u2014 Backend Engineer\",\n    \"body\": \"Hi Sarah,\\n\\nI saw your posting on LinkedIn and wanted to reach out.\",\n    \"bodyType\": \"text\",\n    \"threadId\": null,\n    \"inReplyToMessageId\": null,\n    \"attachments\": []\n}"
+						},
+						{
+							"name": "404 Not Found — Draft does not exist or already sent",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/0000000000000000",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"0000000000000000"
+									]
+								}
+							},
+							"status": "Not Found",
+							"code": 404,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/problem+json"
+								}
+							],
+							"body": "{\n    \"type\": \"/problems/resource-not-found\",\n    \"title\": \"Resource Not Found\",\n    \"status\": 404,\n    \"detail\": \"Draft '0000000000000000' was not found or has already been sent\",\n    \"instance\": \"/api/v1/gmail/drafts/0000000000000000\",\n    \"retryable\": false,\n    \"category\": \"CLIENT_ERROR\"\n}"
+						},
+						{
+							"name": "400 Bad Request — Invalid draft ID format",
+							"originalRequest": {
+								"method": "GET",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/not-valid-id!",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"not-valid-id!"
+									]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/problem+json"
+								}
+							],
+							"body": "{\n    \"type\": \"/problems/validation-error\",\n    \"title\": \"Validation Error\",\n    \"status\": 400,\n    \"detail\": \"Request validation failed\",\n    \"instance\": \"/api/v1/gmail/drafts/not-valid-id!\",\n    \"extensions\": {\n        \"constraint:getDraft.draftId\": \"must match \\\"[0-9a-fA-F]{1,32}\\\"\"\n    }\n}"
+						}
+					]
+				},
+				{
+					"name": "Delete Draft",
+					"request": {
+						"method": "DELETE",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							}
+						],
+						"url": {
+							"raw": "{{baseUrl}}/api/v1/gmail/drafts/:draftId",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"gmail",
+								"drafts",
+								":draftId"
+							],
+							"variable": [
+								{
+									"key": "draftId",
+									"value": "1a2b3c4d5e6f7890",
+									"description": "Gmail draft ID. Must match [0-9a-fA-F]{1,32}. Obtain from the id field in List Drafts response."
+								}
+							]
+						},
+						"description": "Permanently removes a draft from the authenticated user's Gmail Drafts folder. There is no trash or soft-delete — the draft is gone immediately. Returns 204 No Content with an empty response body on success.\n\nIdempotency note: a 404 response indicates the draft is already absent (sent, previously deleted, or never existed). Cleanup workflows may treat 404 as success-equivalent per the contract spec.\n\nQuota cost: 10 units per call (users.drafts.delete).\n\nFeature 003 (drafts-crud). Requires gmail.modify scope."
+					},
+					"response": [
+						{
+							"name": "204 No Content — Draft deleted successfully",
+							"originalRequest": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/1a2b3c4d5e6f7890",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"1a2b3c4d5e6f7890"
+									]
+								}
+							},
+							"status": "No Content",
+							"code": 204,
+							"_postman_previewlanguage": "text",
+							"header": [
+								{
+									"key": "X-Gmail-Quota-Used",
+									"value": "10"
+								},
+								{
+									"key": "X-RateLimit-Limit",
+									"value": "250"
+								},
+								{
+									"key": "X-RateLimit-Remaining",
+									"value": "240"
+								},
+								{
+									"key": "X-RateLimit-Reset",
+									"value": "1746835200"
+								}
+							],
+							"body": ""
+						},
+						{
+							"name": "404 Not Found — Draft already deleted, sent, or never existed",
+							"originalRequest": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/0000000000000000",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"0000000000000000"
+									]
+								}
+							},
+							"status": "Not Found",
+							"code": 404,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/problem+json"
+								}
+							],
+							"body": "{\n    \"type\": \"/problems/resource-not-found\",\n    \"title\": \"Resource Not Found\",\n    \"status\": 404,\n    \"detail\": \"Draft '0000000000000000' was not found or has already been sent\",\n    \"instance\": \"/api/v1/gmail/drafts/0000000000000000\",\n    \"retryable\": false,\n    \"category\": \"CLIENT_ERROR\"\n}"
+						},
+						{
+							"name": "400 Bad Request — Invalid draft ID format",
+							"originalRequest": {
+								"method": "DELETE",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									}
+								],
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/not-valid-id!",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"not-valid-id!"
+									]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/problem+json"
+								}
+							],
+							"body": "{\n    \"type\": \"/problems/validation-error\",\n    \"title\": \"Validation Error\",\n    \"status\": 400,\n    \"detail\": \"Request validation failed\",\n    \"instance\": \"/api/v1/gmail/drafts/not-valid-id!\",\n    \"extensions\": {\n        \"constraint:deleteDraft.draftId\": \"must match \\\"[0-9a-fA-F]{1,32}\\\"\"\n    }\n}"
+						}
+					]
+				},
+				{
+					"name": "Update Draft",
+					"request": {
+						"method": "PUT",
+						"header": [
+							{
+								"key": "Authorization",
+								"value": "Bearer {{token}}"
+							},
+							{
+								"key": "Content-Type",
+								"value": "application/json"
+							}
+						],
+						"body": {
+							"mode": "raw",
+							"raw": "{\n    \"to\": [\"hiring-manager@bigcorp.example\"],\n    \"cc\": [],\n    \"bcc\": [],\n    \"subject\": \"Following up \\u2014 Senior Backend Engineer application (revised)\",\n    \"body\": \"<p>Hi,</p><p>I wanted to follow up and share a revised cover letter.</p>\",\n    \"bodyType\": \"html\",\n    \"threadId\": null,\n    \"inReplyToMessageId\": null,\n    \"attachments\": []\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "{{baseUrl}}/api/v1/gmail/drafts/:draftId",
+							"host": [
+								"{{baseUrl}}"
+							],
+							"path": [
+								"api",
+								"v1",
+								"gmail",
+								"drafts",
+								":draftId"
+							],
+							"variable": [
+								{
+									"key": "draftId",
+									"value": "1a2b3c4d5e6f7890",
+									"description": "Gmail draft ID. Must match [0-9a-fA-F]{1,32}. Obtain from the id field in List Drafts response."
+								}
+							]
+						},
+						"description": "Replaces the entire content of an existing draft with a new SendMessageDTO payload. PUT semantics: the new content fully replaces the old content — no partial update. If attachments are omitted from the request body, the updated draft will have no attachments even if the original had some.\n\nThe request body accepts the same SendMessageDTO shape as POST /api/v1/gmail/drafts, including all optional fields: cc, bcc, threadId, inReplyToMessageId, and attachments (base64-encoded). All the same validation rules apply (email format, size limits, header injection checks, 25 MB payload cap).\n\nReturns 200 OK with a DraftDetailResponse showing the post-update state — the same shape as GET /api/v1/gmail/drafts/{id}. No follow-up GET call is needed.\n\nQuota cost: 15 units (users.drafts.update). Add 5 extra units if inReplyToMessageId is supplied (threading metadata lookup).\n\nFeature 003 (drafts-crud). Requires gmail.modify scope."
+					},
+					"response": [
+						{
+							"name": "200 OK — Draft updated (subject + body, no attachments)",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"to\": [\"hiring-manager@bigcorp.example\"],\n    \"subject\": \"Following up \\u2014 Senior Backend Engineer application (revised)\",\n    \"body\": \"<p>Hi,</p><p>I wanted to follow up and share a revised cover letter.</p>\",\n    \"bodyType\": \"html\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/1a2b3c4d5e6f7890",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"1a2b3c4d5e6f7890"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "X-Gmail-Quota-Used",
+									"value": "15"
+								},
+								{
+									"key": "X-RateLimit-Limit",
+									"value": "250"
+								},
+								{
+									"key": "X-RateLimit-Remaining",
+									"value": "235"
+								},
+								{
+									"key": "X-RateLimit-Reset",
+									"value": "1746835200"
+								}
+							],
+							"body": "{\n    \"id\": \"1a2b3c4d5e6f7890\",\n    \"to\": [\"hiring-manager@bigcorp.example\"],\n    \"cc\": [],\n    \"bcc\": [],\n    \"subject\": \"Following up \\u2014 Senior Backend Engineer application (revised)\",\n    \"body\": \"<p>Hi,</p><p>I wanted to follow up and share a revised cover letter.</p>\",\n    \"bodyType\": \"html\",\n    \"threadId\": null,\n    \"inReplyToMessageId\": null,\n    \"attachments\": []\n}"
+						},
+						{
+							"name": "200 OK — Draft updated with attachment",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"to\": [\"hiring-manager@bigcorp.example\"],\n    \"subject\": \"Application \\u2014 Senior Backend Engineer (r\\u00e9sum\\u00e9 attached)\",\n    \"body\": \"<p>Hi,</p><p>Please find my r\\u00e9sum\\u00e9 attached.</p>\",\n    \"bodyType\": \"html\",\n    \"attachments\": [\n        {\n            \"filename\": \"resume-2026-v2.pdf\",\n            \"mimeType\": \"application/pdf\",\n            \"base64Data\": \"JVBERi0xLjQKMSAwIG9iago...\"\n        }\n    ]\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/1a2b3c4d5e6f7890",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"1a2b3c4d5e6f7890"
+									]
+								}
+							},
+							"status": "OK",
+							"code": 200,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/json"
+								},
+								{
+									"key": "X-Gmail-Quota-Used",
+									"value": "15"
+								},
+								{
+									"key": "X-RateLimit-Limit",
+									"value": "250"
+								},
+								{
+									"key": "X-RateLimit-Remaining",
+									"value": "235"
+								},
+								{
+									"key": "X-RateLimit-Reset",
+									"value": "1746835200"
+								}
+							],
+							"body": "{\n    \"id\": \"1a2b3c4d5e6f7890\",\n    \"to\": [\"hiring-manager@bigcorp.example\"],\n    \"cc\": [],\n    \"bcc\": [],\n    \"subject\": \"Application \\u2014 Senior Backend Engineer (r\\u00e9sum\\u00e9 attached)\",\n    \"body\": \"<p>Hi,</p><p>Please find my r\\u00e9sum\\u00e9 attached.</p>\",\n    \"bodyType\": \"html\",\n    \"threadId\": null,\n    \"inReplyToMessageId\": null,\n    \"attachments\": [\n        {\n            \"filename\": \"resume-2026-v2.pdf\",\n            \"mimeType\": \"application/pdf\",\n            \"sizeBytes\": 249856\n        }\n    ]\n}"
+						},
+						{
+							"name": "404 Not Found — Draft does not exist",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"to\": [\"hiring-manager@bigcorp.example\"],\n    \"subject\": \"Updated subject\",\n    \"body\": \"Updated body.\",\n    \"bodyType\": \"text\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/0000000000000000",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"0000000000000000"
+									]
+								}
+							},
+							"status": "Not Found",
+							"code": 404,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/problem+json"
+								}
+							],
+							"body": "{\n    \"type\": \"/problems/resource-not-found\",\n    \"title\": \"Resource Not Found\",\n    \"status\": 404,\n    \"detail\": \"Draft '0000000000000000' was not found or has already been sent\",\n    \"instance\": \"/api/v1/gmail/drafts/0000000000000000\",\n    \"retryable\": false,\n    \"category\": \"CLIENT_ERROR\"\n}"
+						},
+						{
+							"name": "400 Bad Request — Validation failure (missing recipients)",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"to\": [],\n    \"subject\": \"Missing recipients\",\n    \"body\": \"Body text.\",\n    \"bodyType\": \"text\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/1a2b3c4d5e6f7890",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"1a2b3c4d5e6f7890"
+									]
+								}
+							},
+							"status": "Bad Request",
+							"code": 400,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/problem+json"
+								}
+							],
+							"body": "{\n    \"type\": \"/problems/validation-error\",\n    \"title\": \"Validation Error\",\n    \"status\": 400,\n    \"detail\": \"Request validation failed\",\n    \"instance\": \"/api/v1/gmail/drafts/1a2b3c4d5e6f7890\",\n    \"extensions\": {\n        \"field:to\": \"must not be empty\"\n    }\n}"
+						},
+						{
+							"name": "422 Unprocessable Entity — inReplyToMessageId references non-existent message",
+							"originalRequest": {
+								"method": "PUT",
+								"header": [
+									{
+										"key": "Authorization",
+										"value": "Bearer {{token}}"
+									},
+									{
+										"key": "Content-Type",
+										"value": "application/json"
+									}
+								],
+								"body": {
+									"mode": "raw",
+									"raw": "{\n    \"to\": [\"hiring-manager@bigcorp.example\"],\n    \"subject\": \"Re: Nonexistent thread\",\n    \"body\": \"This should fail.\",\n    \"bodyType\": \"text\",\n    \"inReplyToMessageId\": \"0000000000000000\"\n}"
+								},
+								"url": {
+									"raw": "{{baseUrl}}/api/v1/gmail/drafts/1a2b3c4d5e6f7890",
+									"host": [
+										"{{baseUrl}}"
+									],
+									"path": [
+										"api",
+										"v1",
+										"gmail",
+										"drafts",
+										"1a2b3c4d5e6f7890"
+									]
+								}
+							},
+							"status": "Unprocessable Entity",
+							"code": 422,
+							"_postman_previewlanguage": "json",
+							"header": [
+								{
+									"key": "Content-Type",
+									"value": "application/problem+json"
+								}
+							],
+							"body": "{\n    \"type\": \"/problems/original-message-not-found\",\n    \"title\": \"Original Message Not Found\",\n    \"status\": 422,\n    \"detail\": \"The message referenced by inReplyToMessageId '0000000000000000' does not exist or is not accessible in the authenticated account\",\n    \"instance\": \"/api/v1/gmail/drafts/1a2b3c4d5e6f7890\",\n    \"retryable\": false,\n    \"category\": \"CLIENT_ERROR\"\n}"
+						}
+					]
 				}
 			],
-			"description": "Send emails directly or stage them as drafts for review. All three endpoints require gmail.send scope (or the broader mail.google.com scope). POST /drafts is the recommended default path for AI-personalized outreach.\n\nFeature 002 (threading-attachments) adds three optional fields to POST /messages and POST /drafts:\n- threadId: places the outgoing message in an existing thread\n- inReplyToMessageId: triggers RFC 5322 In-Reply-To / References header construction (costs ~5 extra quota units)\n- attachments: base64-encoded file attachments; total payload capped at 25 MB"
+			"description": "Send emails directly or stage them as drafts for review. All three endpoints require gmail.send scope (or the broader mail.google.com scope). POST /drafts is the recommended default path for AI-personalized outreach.\n\nFeature 002 (threading-attachments) adds three optional fields to POST /messages and POST /drafts:\n- threadId: places the outgoing message in an existing thread\n- inReplyToMessageId: triggers RFC 5322 In-Reply-To / References header construction (costs ~5 extra quota units)\n- attachments: base64-encoded file attachments; total payload capped at 25 MB\n\nFeature 003 (drafts-crud) adds four endpoints for managing existing drafts: GET /drafts (list), GET /drafts/{id} (detail), DELETE /drafts/{id} (cancel), PUT /drafts/{id} (replace content). All four require gmail.modify scope."
 		},
 		{
 			"name": "Test Examples",

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>com.aucontraire</groupId>
     <artifactId>gmail-buddy</artifactId>
-    <version>0.3.0-SNAPSHOT</version>
+    <version>0.4.0-SNAPSHOT</version>
     <name>gmail-buddy</name>
     <description>gmail-buddy</description>
     <url/>

--- a/src/main/java/com/aucontraire/gmailbuddy/config/RateLimitInterceptor.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/config/RateLimitInterceptor.java
@@ -50,6 +50,9 @@ public class RateLimitInterceptor implements HandlerInterceptor {
 
     private static final Logger logger = LoggerFactory.getLogger(RateLimitInterceptor.class);
 
+    /** Default page size for pre-execution quota estimate on GET /drafts. */
+    static final int DEFAULT_DRAFT_LIST_LIMIT = 25;
+
     private final RateLimitService rateLimitService;
     private final GmailQuotaEstimator quotaEstimator;
 
@@ -181,6 +184,19 @@ public class RateLimitInterceptor implements HandlerInterceptor {
             // Threading headers are baked into the draft at creation time; this call
             // always costs the same regardless of whether the draft is threaded (Decision 13).
             return quotaEstimator.estimateSendDraftQuota();
+        } else if (uri.matches(".*/drafts/[^/]+") && "GET".equals(method)) {
+            // GET /drafts/{id} — get draft detail
+            return quotaEstimator.estimateGetDraftQuota();
+        } else if (uri.matches(".*/drafts/[^/]+") && "DELETE".equals(method)) {
+            // DELETE /drafts/{id}
+            return quotaEstimator.estimateDeleteDraftQuota();
+        } else if (uri.matches(".*/drafts/[^/]+") && "PUT".equals(method)) {
+            // PUT /drafts/{id} — update draft
+            return quotaEstimator.estimateUpdateDraftQuota();
+        } else if (uri.endsWith("/drafts") && "GET".equals(method)) {
+            // GET /drafts — list; pre-execution estimate using DEFAULT_DRAFT_LIST_LIMIT
+            // Controller updates the request attribute post-execution with the actual item count
+            return quotaEstimator.estimateListDraftsQuota(DEFAULT_DRAFT_LIST_LIMIT);
         } else if (uri.endsWith("/messages") || uri.endsWith("/messages/latest")) {
             // GET /messages or /messages/latest - list messages
             return quotaEstimator.estimateListMessagesQuota(0); // Can't know count yet

--- a/src/main/java/com/aucontraire/gmailbuddy/config/ResponseHeaderFilter.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/config/ResponseHeaderFilter.java
@@ -170,6 +170,15 @@ public class ResponseHeaderFilter implements Filter {
             // Execute the rest of the filter chain with wrapped response
             chain.doFilter(request, responseWrapper);
 
+            // For no-body responses (e.g. 204 No Content), none of getOutputStream(),
+            // getWriter(), sendError(), sendRedirect(), or flushBuffer() is invoked by
+            // the framework, so addHeadersIfNeeded() inside the wrapper is never
+            // triggered. Calling flushBuffer() here ensures headers are committed even
+            // when the response body is empty (FR-019).
+            if (!responseWrapper.isCommitted()) {
+                responseWrapper.flushBuffer();
+            }
+
             logger.debug("ResponseHeaderFilter: Completed request {} - committed: {}",
                         httpRequest.getRequestURI(), responseWrapper.isCommitted());
 

--- a/src/main/java/com/aucontraire/gmailbuddy/controller/GmailController.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/controller/GmailController.java
@@ -1,6 +1,7 @@
 package com.aucontraire.gmailbuddy.controller;
 
 import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
+import com.aucontraire.gmailbuddy.config.ResponseHeaderFilter;
 import com.aucontraire.gmailbuddy.dto.DeleteResult;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaDTO;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaWithLabelsDTO;
@@ -9,14 +10,19 @@ import com.aucontraire.gmailbuddy.dto.common.ResponseMetadata;
 import com.aucontraire.gmailbuddy.dto.error.ErrorResponse;
 import com.aucontraire.gmailbuddy.dto.response.BulkDeleteResponse;
 import com.aucontraire.gmailbuddy.dto.response.DeleteOperationResult;
+import com.aucontraire.gmailbuddy.dto.response.DraftDetailResponse;
+import com.aucontraire.gmailbuddy.dto.response.DraftListResponse;
 import com.aucontraire.gmailbuddy.dto.response.DraftResponse;
 import com.aucontraire.gmailbuddy.dto.response.LabelModificationResponse;
 import com.aucontraire.gmailbuddy.dto.response.SendMessageResponse;
 import com.aucontraire.gmailbuddy.dto.response.MessageListResponse;
 import com.aucontraire.gmailbuddy.dto.response.MessageSummary;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
 import com.aucontraire.gmailbuddy.service.BulkOperationResult;
 import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.DraftDetailResult;
+import com.aucontraire.gmailbuddy.service.DraftListResult;
 import com.aucontraire.gmailbuddy.service.GmailService;
 import com.aucontraire.gmailbuddy.service.MessageListResult;
 import com.aucontraire.gmailbuddy.service.SentMessageResult;
@@ -29,10 +35,17 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
@@ -40,8 +53,8 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientService;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import jakarta.validation.Valid;
 
 import java.net.URI;
 import java.util.Collections;
@@ -51,21 +64,25 @@ import java.util.stream.Collectors;
 @RestController
 @RequestMapping("/api/v1/gmail")
 @Tag(name = "Gmail", description = "Gmail message management operations")
+@Validated
 public class GmailController {
 
     private final GmailService gmailService;
     private final OAuth2AuthorizedClientService authorizedClientService;
     private final GmailBuddyProperties properties;
     private final ResponseMapper responseMapper;
+    private final GmailMessageMapper gmailMessageMapper;
     private final Logger logger = LoggerFactory.getLogger(GmailController.class);
 
     @Autowired
     public GmailController(GmailService gmailService, OAuth2AuthorizedClientService authorizedClientService,
-                          GmailBuddyProperties properties, ResponseMapper responseMapper) {
+                          GmailBuddyProperties properties, ResponseMapper responseMapper,
+                          GmailMessageMapper gmailMessageMapper) {
         this.gmailService = gmailService;
         this.authorizedClientService = authorizedClientService;
         this.properties = properties;
         this.responseMapper = responseMapper;
+        this.gmailMessageMapper = gmailMessageMapper;
     }
 
     /**
@@ -570,6 +587,192 @@ public class GmailController {
 
         URI location = URI.create("/api/v1/gmail/messages/" + result.messageId() + "/body");
         return ResponseEntity.created(location).body(SendMessageResponse.sent(result.messageId(), result.threadId()));
+    }
+
+    /**
+     * GET /drafts — List pending drafts with pagination.
+     *
+     * <p>Calls {@code users.drafts.list} then fetches each draft with
+     * {@code users.drafts.get(format=FULL)} to populate recipients, subject,
+     * and snippet. Updates the {@code X-Gmail-Quota-Used} request attribute
+     * post-execution with the actual cost: {@code 1 + N * 5}.</p>
+     */
+    @Operation(
+        summary = "List pending drafts",
+        description = "Returns a paginated list of draft summaries. Each item includes recipients, subject, snippet, " +
+                      "thread ID, and attachment count. Internally calls users.drafts.get per item for enrichment."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Successfully retrieved drafts",
+            content = @Content(schema = @Schema(implementation = DraftListResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid query parameters",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - invalid or missing authentication",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient Gmail permissions (requires gmail.modify scope)",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "429", description = "Rate limit exceeded",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "502", description = "Gmail API error",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "503", description = "Gmail API unavailable",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping(value = "/drafts", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<DraftListResponse> listDrafts(
+            @Parameter(description = "Pagination token from a prior response (max 255 chars)")
+            @RequestParam(required = false) @Size(max = 255) String pageToken,
+            @Parameter(description = "Maximum number of drafts to return (1–50, default 25)")
+            @RequestParam(defaultValue = "25") @Min(1) @Max(50) int limit,
+            HttpServletRequest request) {
+
+        String userId = properties.gmailApi().defaultUserId();
+        DraftListResult result = gmailService.listDrafts(userId, pageToken, limit);
+
+        // Update actual quota: 1 (list call) + N * 5 (per-item get calls)
+        int actualQuota = 1 + result.drafts().size() * 5;
+        request.setAttribute(ResponseHeaderFilter.ATTR_GMAIL_QUOTA_USED, actualQuota);
+
+        DraftListResponse response = gmailMessageMapper.toDraftListResponse(result);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * GET /drafts/{draftId} — Get full content of a single draft.
+     *
+     * <p>Calls {@code users.drafts.get(format=FULL)} and returns the full
+     * {@link DraftDetailResponse} including recipients, subject, body,
+     * threading fields, and attachment metadata.</p>
+     */
+    @Operation(
+        summary = "Get draft detail",
+        description = "Returns the full contents of a single draft including recipients, subject, body, " +
+                      "threading fields, and attachment metadata. No binary content is returned."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Draft retrieved successfully",
+            content = @Content(schema = @Schema(implementation = DraftDetailResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid draft ID format",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - invalid or missing authentication",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient Gmail permissions (requires gmail.modify scope)",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Draft not found",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "429", description = "Rate limit exceeded",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "502", description = "Gmail API error",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "503", description = "Gmail API unavailable",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @GetMapping(value = "/drafts/{draftId}", produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<DraftDetailResponse> getDraft(
+            @Parameter(description = "The Gmail-assigned draft identifier", required = true)
+            @PathVariable @Pattern(regexp = "[A-Za-z0-9_-]{1,128}") String draftId) {
+
+        String userId = properties.gmailApi().defaultUserId();
+        DraftDetailResult result = gmailService.getDraft(userId, draftId);
+        DraftDetailResponse response = gmailMessageMapper.toDraftDetailResponse(result);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * DELETE /drafts/{draftId} — Permanently delete a draft.
+     *
+     * <p>Calls {@code users.drafts.delete}. Hard delete — the draft does not go
+     * to Trash. Returns 204 No Content on success.</p>
+     */
+    @Operation(
+        summary = "Delete a draft",
+        description = "Permanently deletes a draft. The draft is hard-deleted (not moved to Trash). " +
+                      "Returns 204 No Content on success. If the draft does not exist, returns 404."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "Draft deleted successfully (empty response body)"),
+        @ApiResponse(responseCode = "400", description = "Invalid draft ID format",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - invalid or missing authentication",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient Gmail permissions (requires gmail.modify scope)",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Draft not found",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "429", description = "Rate limit exceeded",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "502", description = "Gmail API error",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "503", description = "Gmail API unavailable",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @DeleteMapping(value = "/drafts/{draftId}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public ResponseEntity<Void> deleteDraft(
+            @Parameter(description = "The Gmail-assigned draft identifier", required = true)
+            @PathVariable @Pattern(regexp = "[A-Za-z0-9_-]{1,128}") String draftId) {
+
+        String userId = properties.gmailApi().defaultUserId();
+        gmailService.deleteDraft(userId, draftId);
+        return ResponseEntity.noContent().build();
+    }
+
+    /**
+     * PUT /drafts/{draftId} — Replace the content of an existing draft.
+     *
+     * <p>Full replacement via {@code users.drafts.update}. All fields (recipients,
+     * subject, body, threading, attachments) are replaced by the request body.
+     * Omitted optional fields (cc, bcc, attachments, threading) are cleared.
+     * Returns the updated {@link DraftDetailResponse}.</p>
+     */
+    @Operation(
+        summary = "Update a draft",
+        description = "Replaces the content of an existing draft (full replacement — not a partial update). " +
+                      "Omitted optional fields (cc, bcc, attachments, inReplyToMessageId) are cleared. " +
+                      "Returns the updated draft detail. When inReplyToMessageId is present, a threading " +
+                      "lookup is performed first (total ~20 quota units instead of 15)."
+    )
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Draft updated successfully",
+            content = @Content(schema = @Schema(implementation = DraftDetailResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid request - validation failure or header-injection detected",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "401", description = "Unauthorized - invalid or missing authentication",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "403", description = "Forbidden - insufficient Gmail permissions (requires gmail.modify scope)",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "404", description = "Draft not found",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "413", description = "Payload too large - assembled MIME exceeds 25 MB",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "422", description = "Unprocessable entity - invalid recipient or inReplyToMessageId not found",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "429", description = "Rate limit exceeded",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "502", description = "Gmail API error",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class))),
+        @ApiResponse(responseCode = "503", description = "Gmail API unavailable",
+            content = @Content(schema = @Schema(implementation = ErrorResponse.class)))
+    })
+    @PutMapping(value = "/drafts/{draftId}",
+            consumes = MediaType.APPLICATION_JSON_VALUE,
+            produces = MediaType.APPLICATION_JSON_VALUE)
+    public ResponseEntity<DraftDetailResponse> updateDraft(
+            @Parameter(description = "The Gmail-assigned draft identifier", required = true)
+            @PathVariable @Pattern(regexp = "[A-Za-z0-9_-]{1,128}") String draftId,
+            @Valid @RequestBody SendMessageDTO dto,
+            HttpServletRequest request) {
+
+        String userId = properties.gmailApi().defaultUserId();
+        DraftDetailResult result = gmailService.updateDraft(userId, draftId, dto);
+
+        // If threading lookup was performed, quota is 15 (update) + 5 (lookup) = 20
+        if (dto.inReplyToMessageId() != null) {
+            request.setAttribute(ResponseHeaderFilter.ATTR_GMAIL_QUOTA_USED, 20);
+        }
+
+        DraftDetailResponse response = gmailMessageMapper.toDraftDetailResponse(result);
+        return ResponseEntity.ok(response);
     }
 
     @Operation(

--- a/src/main/java/com/aucontraire/gmailbuddy/dto/response/AttachmentMetadata.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/dto/response/AttachmentMetadata.java
@@ -1,0 +1,27 @@
+package com.aucontraire.gmailbuddy.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * Attachment metadata returned in draft detail responses.
+ *
+ * <p>Contains filename, MIME type, and decoded byte size only — no binary
+ * content. Binary download is out of scope for this feature (tracked as R-019).
+ * See spec FR-006 and data-model §3.</p>
+ *
+ * @param filename  filename from {@code MessagePart.filename} or
+ *                  {@code Content-Disposition} filename parameter
+ * @param mimeType  MIME type from {@code MessagePart.mimeType}
+ * @param sizeBytes decoded byte size estimate from {@code MessagePartBody.size}
+ */
+@Schema(description = "Attachment summary (no binary content)")
+public record AttachmentMetadata(
+        @Schema(description = "Original filename of the attachment", example = "resume-2026.pdf")
+        String filename,
+
+        @Schema(description = "MIME type of the attachment", example = "application/pdf")
+        String mimeType,
+
+        @Schema(description = "Decoded byte size estimate from Gmail API", example = "245760")
+        long sizeBytes
+) {}

--- a/src/main/java/com/aucontraire/gmailbuddy/dto/response/DraftDetailResponse.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/dto/response/DraftDetailResponse.java
@@ -1,0 +1,52 @@
+package com.aucontraire.gmailbuddy.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Full draft response returned by {@code GET /api/v1/gmail/drafts/{id}} and
+ * {@code PUT /api/v1/gmail/drafts/{id}} (FR-006, FR-017).
+ *
+ * <p>Both endpoints return this same record shape to allow callers to reuse
+ * parsing code. The body field is always populated (echoing the full body
+ * regardless of bodyType); attachment metadata excludes binary content per
+ * FR-006 (binary download is out of scope, tracked as R-019).</p>
+ *
+ * <p>See data-model §4 for the canonical field list.</p>
+ */
+@Schema(description = "Full draft contents (no binary attachment data)")
+public record DraftDetailResponse(
+        @Schema(description = "Gmail draft identifier", example = "r-9876543210")
+        String id,
+
+        @Schema(description = "To recipient addresses; empty list if absent",
+                example = "[\"hiring-manager@bigcorp.example\"]")
+        List<String> to,
+
+        @Schema(description = "CC recipient addresses; empty list if absent")
+        List<String> cc,
+
+        @Schema(description = "BCC recipient addresses; empty list if absent")
+        List<String> bcc,
+
+        @Schema(description = "Subject line; null if absent",
+                example = "Following up — Senior Backend Engineer application")
+        String subject,
+
+        @Schema(description = "Decoded body text (HTML or plain per bodyType); null if not extractable")
+        String body,
+
+        @Schema(description = "Body content type", example = "html", allowableValues = {"html", "text"})
+        String bodyType,
+
+        @Schema(description = "Gmail thread ID; null if not a threaded draft", example = "1976a4bc3fe89d0c")
+        String threadId,
+
+        @Schema(description = "Original message ID this draft replies to; null if not a reply",
+                example = "1976a4bc3fe89d0c")
+        String inReplyToMessageId,
+
+        @Schema(description = "Attachment metadata (filename, mimeType, sizeBytes); empty list if no attachments")
+        List<AttachmentMetadata> attachments
+) {}

--- a/src/main/java/com/aucontraire/gmailbuddy/dto/response/DraftListItem.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/dto/response/DraftListItem.java
@@ -1,0 +1,51 @@
+package com.aucontraire.gmailbuddy.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Per-item summary returned in {@code GET /api/v1/gmail/drafts} list responses.
+ *
+ * <p>Populated from {@code users.drafts.get(format=FULL)} per item after the
+ * initial {@code users.drafts.list} call returns the draft IDs. List fields are
+ * never null — the mapper uses {@code List.of()} as the fallback. See data-model §1.</p>
+ *
+ * @param id              Gmail draft identifier
+ * @param to              recipient addresses; {@code List.of()} if absent
+ * @param cc              CC addresses; {@code List.of()} if absent
+ * @param bcc             BCC addresses; {@code List.of()} if absent
+ * @param subject         subject line; null if the header is absent
+ * @param snippet         Gmail-provided body preview (~100 chars)
+ * @param threadId        Gmail thread ID; null if not a threaded draft
+ * @param attachmentCount count of attachment parts; 0 if none
+ */
+@Schema(description = "Summary of a single draft in a list response")
+public record DraftListItem(
+        @Schema(description = "Gmail draft identifier", example = "r-9876543210")
+        String id,
+
+        @Schema(description = "To recipient addresses; empty list if absent",
+                example = "[\"hiring-manager@bigcorp.example\"]")
+        List<String> to,
+
+        @Schema(description = "CC recipient addresses; empty list if absent")
+        List<String> cc,
+
+        @Schema(description = "BCC recipient addresses; empty list if absent")
+        List<String> bcc,
+
+        @Schema(description = "Subject line; null if absent",
+                example = "Following up — Senior Backend Engineer application")
+        String subject,
+
+        @Schema(description = "Gmail-provided body preview (~100 chars)",
+                example = "Hi Sarah, I wanted to follow up on my application...")
+        String snippet,
+
+        @Schema(description = "Gmail thread ID; null if not a threaded draft", example = "1976a4bc3fe89d0c")
+        String threadId,
+
+        @Schema(description = "Count of attachment parts; 0 if no attachments", example = "1")
+        int attachmentCount
+) {}

--- a/src/main/java/com/aucontraire/gmailbuddy/dto/response/DraftListResponse.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/dto/response/DraftListResponse.java
@@ -1,0 +1,29 @@
+package com.aucontraire.gmailbuddy.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.util.List;
+
+/**
+ * Pagination envelope returned by {@code GET /api/v1/gmail/drafts}.
+ *
+ * <p>Mirrors the field-naming convention of {@code MessageListResponse} per FR-003.
+ * The {@code results} list is never null — the mapper uses {@code List.of()} for an
+ * empty page. See data-model §2.</p>
+ *
+ * @param results       page of draft summaries; {@code List.of()} for an empty result
+ * @param nextPageToken token for the next page; null when all results are exhausted
+ * @param totalCount    {@code resultSizeEstimate} from the Gmail API; may be null
+ */
+@Schema(description = "Paginated list of draft summaries")
+public record DraftListResponse(
+        @Schema(description = "Page of draft summaries; empty list if no drafts found")
+        List<DraftListItem> results,
+
+        @Schema(description = "Token for the next page; null when all results are exhausted",
+                example = "AKmmh...")
+        String nextPageToken,
+
+        @Schema(description = "Estimated total count from Gmail API; may be null", example = "42")
+        Integer totalCount
+) {}

--- a/src/main/java/com/aucontraire/gmailbuddy/mapper/GmailMessageMapper.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/mapper/GmailMessageMapper.java
@@ -1,10 +1,23 @@
 package com.aucontraire.gmailbuddy.mapper;
 
+import com.aucontraire.gmailbuddy.dto.response.AttachmentMetadata;
+import com.aucontraire.gmailbuddy.dto.response.DraftDetailResponse;
+import com.aucontraire.gmailbuddy.dto.response.DraftListItem;
+import com.aucontraire.gmailbuddy.dto.response.DraftListResponse;
 import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.DraftDetailResult;
+import com.aucontraire.gmailbuddy.service.DraftListResult;
 import com.aucontraire.gmailbuddy.service.SentMessageResult;
 import com.google.api.services.gmail.model.Draft;
 import com.google.api.services.gmail.model.Message;
+import com.google.api.services.gmail.model.MessagePart;
+import com.google.api.services.gmail.model.MessagePartHeader;
 import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
 
 /**
  * Boundary mapper that converts Gmail SDK types into project-internal domain
@@ -61,5 +74,262 @@ public class GmailMessageMapper {
         String messageId = nestedMessage != null ? nestedMessage.getId() : null;
         String threadId  = nestedMessage != null ? nestedMessage.getThreadId() : null;
         return new DraftCreationResult(draft.getId(), messageId, threadId);
+    }
+
+    /**
+     * Converts a Gmail API {@link Draft} (already fetched with format=FULL) into a
+     * {@link DraftDetailResult} domain record.
+     *
+     * <p>Extracts recipients from MIME headers, body from the message payload,
+     * and attachment metadata from the message part tree. All list fields are
+     * populated with {@code List.of()} when absent — never null.</p>
+     *
+     * @param draft the Gmail API draft; must not be null; message.payload should be present
+     * @return a {@link DraftDetailResult} with all fields populated (lists never null)
+     */
+    public DraftDetailResult toDraftDetailResult(Draft draft) {
+        String draftId = draft.getId();
+
+        Message message = draft.getMessage();
+        if (message == null) {
+            return new DraftDetailResult(
+                    draftId, null, null,
+                    List.of(), List.of(), List.of(),
+                    null, null, null, "text", null, List.of()
+            );
+        }
+
+        String messageId = message.getId();
+        String threadId = message.getThreadId();
+        String snippet = message.getSnippet();
+
+        // Walk MIME headers
+        List<String> to = List.of();
+        List<String> cc = List.of();
+        List<String> bcc = List.of();
+        String subject = null;
+        String inReplyToMessageId = null;
+
+        MessagePart payload = message.getPayload();
+        if (payload != null) {
+            List<MessagePartHeader> headers = payload.getHeaders();
+            if (headers != null) {
+                List<String> toList = new ArrayList<>();
+                List<String> ccList = new ArrayList<>();
+                List<String> bccList = new ArrayList<>();
+
+                for (MessagePartHeader header : headers) {
+                    String name = header.getName();
+                    String value = header.getValue();
+                    if (name == null || value == null) continue;
+
+                    switch (name.toLowerCase()) {
+                        case "to" -> parseAddressList(value, toList);
+                        case "cc" -> parseAddressList(value, ccList);
+                        case "bcc" -> parseAddressList(value, bccList);
+                        case "subject" -> subject = value;
+                        case "in-reply-to" -> inReplyToMessageId = stripAngleBrackets(value);
+                        default -> { /* ignore other headers */ }
+                    }
+                }
+
+                to = toList.isEmpty() ? List.of() : List.copyOf(toList);
+                cc = ccList.isEmpty() ? List.of() : List.copyOf(ccList);
+                bcc = bccList.isEmpty() ? List.of() : List.copyOf(bccList);
+            }
+        }
+
+        // Walk MIME payload tree for body and attachments
+        BodyExtractionResult bodyResult = new BodyExtractionResult();
+        List<AttachmentMetadata> attachments = new ArrayList<>();
+
+        if (payload != null) {
+            extractBodyAndAttachments(payload, bodyResult, attachments);
+        }
+
+        String body = bodyResult.body;
+        String bodyType = bodyResult.bodyType != null ? bodyResult.bodyType : "text";
+
+        return new DraftDetailResult(
+                draftId, messageId, threadId,
+                to, cc, bcc,
+                subject, snippet, body, bodyType,
+                inReplyToMessageId,
+                attachments.isEmpty() ? List.of() : List.copyOf(attachments)
+        );
+    }
+
+    /**
+     * Projects a {@link DraftDetailResult} to a {@link DraftListItem} (summary).
+     * Used when building list responses from the enriched draft data.
+     *
+     * @param result the enriched draft domain record
+     * @return a {@link DraftListItem} with summary fields
+     */
+    public DraftListItem toDraftListItem(DraftDetailResult result) {
+        return new DraftListItem(
+                result.draftId(),
+                result.to(),
+                result.cc(),
+                result.bcc(),
+                result.subject(),
+                result.snippet(),
+                result.threadId(),
+                result.attachments().size()
+        );
+    }
+
+    /**
+     * Projects a {@link DraftDetailResult} to a {@link DraftDetailResponse} (full response DTO).
+     * Used by GmailController on GET /drafts/{id} and PUT /drafts/{id} responses.
+     * One-to-one field mapping; null fields pass through as null.
+     *
+     * @param result the enriched draft domain record
+     * @return a {@link DraftDetailResponse} ready for serialization
+     */
+    public DraftDetailResponse toDraftDetailResponse(DraftDetailResult result) {
+        return new DraftDetailResponse(
+                result.draftId(),
+                result.to(),
+                result.cc(),
+                result.bcc(),
+                result.subject(),
+                result.body(),
+                result.bodyType(),
+                result.threadId(),
+                result.inReplyToMessageId(),
+                result.attachments()
+        );
+    }
+
+    /**
+     * Projects a {@link DraftListResult} to a {@link DraftListResponse} (paginated response DTO).
+     * Maps each {@link DraftDetailResult} in {@code result.drafts()} via
+     * {@link #toDraftListItem}; passes through {@code nextPageToken} and {@code totalCount}.
+     * Used by GmailController on GET /drafts response.
+     *
+     * @param result the per-request domain value object
+     * @return a {@link DraftListResponse} ready for serialization
+     */
+    public DraftListResponse toDraftListResponse(DraftListResult result) {
+        List<DraftListItem> items = result.drafts().stream()
+                .map(this::toDraftListItem)
+                .toList();
+        return new DraftListResponse(items, result.nextPageToken(), result.totalCount());
+    }
+
+    // -------------------------------------------------------------------------
+    // Private helpers
+    // -------------------------------------------------------------------------
+
+    /**
+     * Parses a comma-separated address list header value (e.g., To, Cc, Bcc)
+     * and adds each trimmed address to the target list.
+     */
+    private void parseAddressList(String headerValue, List<String> target) {
+        if (headerValue == null || headerValue.isBlank()) return;
+        String[] parts = headerValue.split(",");
+        for (String part : parts) {
+            String trimmed = part.trim();
+            if (!trimmed.isEmpty()) {
+                target.add(trimmed);
+            }
+        }
+    }
+
+    /**
+     * Strips leading and trailing angle brackets from an RFC 5322 message ID value.
+     * E.g., {@code <CABc123@mail.gmail.com>} → {@code CABc123@mail.gmail.com}.
+     */
+    private String stripAngleBrackets(String value) {
+        if (value == null) return null;
+        String trimmed = value.trim();
+        if (trimmed.startsWith("<") && trimmed.endsWith(">")) {
+            return trimmed.substring(1, trimmed.length() - 1);
+        }
+        return trimmed;
+    }
+
+    /**
+     * Mutable holder for the body extraction result during recursive MIME tree walk.
+     * HTML body wins over text/plain (set when bodyType is not yet "html").
+     */
+    private static class BodyExtractionResult {
+        String body;
+        String bodyType;
+    }
+
+    /**
+     * Recursively walks a {@link MessagePart} tree to extract the body text and
+     * attachment metadata.
+     *
+     * <p>Strategy:
+     * <ul>
+     *   <li>If the part has {@code filename} set (non-empty), it is an attachment
+     *       — collect its metadata and skip body extraction for this part.</li>
+     *   <li>If the part has {@code text/html} MIME type, decode its body data and
+     *       set as body (bodyType = "html"); HTML wins over plain text.</li>
+     *   <li>If the part has {@code text/plain} MIME type and no body has been found
+     *       yet, decode and set as body (bodyType = "text").</li>
+     *   <li>If the part has sub-parts (multipart/*), recurse into each.</li>
+     * </ul>
+     * </p>
+     */
+    private void extractBodyAndAttachments(MessagePart part,
+                                           BodyExtractionResult bodyResult,
+                                           List<AttachmentMetadata> attachments) {
+        if (part == null) return;
+
+        String mimeType = part.getMimeType() != null ? part.getMimeType().toLowerCase() : "";
+        String filename = part.getFilename();
+
+        // Attachment: has a non-empty filename
+        if (filename != null && !filename.isBlank()) {
+            long sizeBytes = 0L;
+            if (part.getBody() != null && part.getBody().getSize() != null) {
+                sizeBytes = part.getBody().getSize();
+            }
+            attachments.add(new AttachmentMetadata(filename, part.getMimeType() != null ? part.getMimeType() : "", sizeBytes));
+            return;
+        }
+
+        // Body parts
+        if (mimeType.equals("text/html")) {
+            String decoded = decodeBodyData(part);
+            if (decoded != null) {
+                // HTML always wins
+                bodyResult.body = decoded;
+                bodyResult.bodyType = "html";
+            }
+        } else if (mimeType.equals("text/plain")) {
+            // Only use plain text if we don't already have an HTML body
+            if (!"html".equals(bodyResult.bodyType)) {
+                String decoded = decodeBodyData(part);
+                if (decoded != null) {
+                    bodyResult.body = decoded;
+                    bodyResult.bodyType = "text";
+                }
+            }
+        }
+
+        // Recurse into sub-parts (multipart/*)
+        List<MessagePart> parts = part.getParts();
+        if (parts != null) {
+            for (MessagePart subPart : parts) {
+                extractBodyAndAttachments(subPart, bodyResult, attachments);
+            }
+        }
+    }
+
+    /**
+     * Decodes the base64url-encoded body data of a {@link MessagePart} to a UTF-8 string.
+     * Returns null if the body data is absent or empty.
+     */
+    private String decodeBodyData(MessagePart part) {
+        if (part.getBody() == null) return null;
+        String data = part.getBody().getData();
+        if (data == null || data.isBlank()) return null;
+        byte[] decoded = Base64.getUrlDecoder().decode(data);
+        return new String(decoded, StandardCharsets.UTF_8);
     }
 }

--- a/src/main/java/com/aucontraire/gmailbuddy/ratelimit/GmailQuotaEstimator.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/ratelimit/GmailQuotaEstimator.java
@@ -33,6 +33,10 @@ public class GmailQuotaEstimator {
     private static final int MESSAGES_SEND_QUOTA = 100;
     private static final int DRAFTS_CREATE_QUOTA = 10;
     private static final int DRAFTS_SEND_QUOTA = 100;
+    private static final int DRAFTS_LIST_QUOTA = 1;
+    private static final int DRAFTS_GET_QUOTA = 5;
+    private static final int DRAFTS_DELETE_QUOTA = 10;
+    private static final int DRAFTS_UPDATE_QUOTA = 15;
 
     /**
      * Estimates quota usage for listing messages.
@@ -193,5 +197,51 @@ public class GmailQuotaEstimator {
         int quota = MESSAGES_GET_QUOTA + DRAFTS_CREATE_QUOTA;
         logger.debug("Estimated quota for threaded create draft: {} units", quota);
         return quota;
+    }
+
+    /**
+     * Estimates quota for a list-drafts page call.
+     * Actual cost: 1 (list call) + itemCount × 5 (per-item get calls).
+     *
+     * @param itemCount number of items actually returned on this page
+     * @return estimated quota units for this page
+     */
+    public int estimateListDraftsQuota(int itemCount) {
+        int quota = DRAFTS_LIST_QUOTA + (itemCount * DRAFTS_GET_QUOTA);
+        logger.debug("Estimated quota for listing {} drafts: {} units", itemCount, quota);
+        return quota;
+    }
+
+    /**
+     * Estimates quota for a single-draft get (users.drafts.get, format=FULL).
+     * ~5 units.
+     *
+     * @return Estimated quota units consumed
+     */
+    public int estimateGetDraftQuota() {
+        logger.debug("Estimated quota for getting draft: {} units", DRAFTS_GET_QUOTA);
+        return DRAFTS_GET_QUOTA;
+    }
+
+    /**
+     * Estimates quota for a draft delete (users.drafts.delete).
+     * ~10 units.
+     *
+     * @return Estimated quota units consumed
+     */
+    public int estimateDeleteDraftQuota() {
+        logger.debug("Estimated quota for deleting draft: {} units", DRAFTS_DELETE_QUOTA);
+        return DRAFTS_DELETE_QUOTA;
+    }
+
+    /**
+     * Estimates quota for a draft update (users.drafts.update).
+     * ~15 units (5 internal read + 10 write).
+     *
+     * @return Estimated quota units consumed
+     */
+    public int estimateUpdateDraftQuota() {
+        logger.debug("Estimated quota for updating draft: {} units", DRAFTS_UPDATE_QUOTA);
+        return DRAFTS_UPDATE_QUOTA;
     }
 }

--- a/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepository.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepository.java
@@ -2,6 +2,8 @@ package com.aucontraire.gmailbuddy.repository;
 
 import com.aucontraire.gmailbuddy.service.BulkOperationResult;
 import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.DraftDetailResult;
+import com.aucontraire.gmailbuddy.service.DraftListResult;
 import com.aucontraire.gmailbuddy.service.MessageListResult;
 import com.aucontraire.gmailbuddy.service.OriginalMessageLookup;
 import com.aucontraire.gmailbuddy.service.SentMessageResult;
@@ -119,6 +121,57 @@ public interface GmailRepository {
      *                              on other Gmail send failures
      */
     SentMessageResult sendDraft(String userId, String draftId) throws IOException;
+
+    /**
+     * Returns a paginated list of drafts for the specified user.
+     * Internally calls users.drafts.list followed by users.drafts.get per item
+     * to populate recipient, subject, and snippet fields.
+     *
+     * @param userId    the Gmail user identifier; typically "me"
+     * @param pageToken opaque token from a prior response, or null for the first page
+     * @param limit     maximum number of items to return (1–50)
+     * @return a DraftListResult containing enriched draft summaries and pagination state
+     * @throws IOException on Gmail API communication failure
+     */
+    DraftListResult listDrafts(String userId, String pageToken, int limit) throws IOException;
+
+    /**
+     * Returns the full content of the specified draft.
+     *
+     * @param userId  the Gmail user identifier; typically "me"
+     * @param draftId the Gmail draft identifier
+     * @return a DraftDetailResult with all parsed fields
+     * @throws com.aucontraire.gmailbuddy.exception.ResourceNotFoundException
+     *         if the draft does not exist (Gmail 404)
+     * @throws IOException on Gmail API communication failure
+     */
+    DraftDetailResult getDraft(String userId, String draftId) throws IOException;
+
+    /**
+     * Permanently deletes the specified draft.
+     * users.drafts.delete is a hard delete; no trash or soft-delete option.
+     *
+     * @param userId  the Gmail user identifier; typically "me"
+     * @param draftId the Gmail draft identifier
+     * @throws com.aucontraire.gmailbuddy.exception.ResourceNotFoundException
+     *         if the draft does not exist (Gmail 404)
+     * @throws IOException on Gmail API communication failure
+     */
+    void deleteDraft(String userId, String draftId) throws IOException;
+
+    /**
+     * Replaces the content of the specified draft with the provided MimeMessage.
+     * Uses users.drafts.update — full replacement, no partial update.
+     *
+     * @param userId      the Gmail user identifier; typically "me"
+     * @param draftId     the Gmail draft identifier
+     * @param mimeMessage the fully-constructed replacement MIME message
+     * @return the updated draft's identifiers (draftId, messageId, threadId)
+     * @throws com.aucontraire.gmailbuddy.exception.ResourceNotFoundException
+     *         if the draft does not exist (Gmail 404)
+     * @throws IOException on Gmail API communication failure
+     */
+    DraftCreationResult updateDraft(String userId, String draftId, MimeMessage mimeMessage) throws IOException;
 
     /**
      * Fetches the RFC 5322 {@code Message-ID} header and {@code threadId} from the

--- a/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/repository/GmailRepositoryImpl.java
@@ -17,6 +17,8 @@ import com.aucontraire.gmailbuddy.service.OriginalMessageLookup;
 import com.aucontraire.gmailbuddy.exception.ValidationException;
 import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.DraftDetailResult;
+import com.aucontraire.gmailbuddy.service.DraftListResult;
 import com.aucontraire.gmailbuddy.service.SentMessageResult;
 import com.aucontraire.gmailbuddy.service.TokenProvider;
 import com.aucontraire.gmailbuddy.service.BulkOperationResult;
@@ -390,6 +392,179 @@ public class GmailRepositoryImpl implements GmailRepository {
             return result;
         } catch (GeneralSecurityException e) {
             throw new IOException("Security exception creating Gmail service", e);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Draft CRUD — listDrafts, getDraft, deleteDraft, updateDraft
+    // -------------------------------------------------------------------------
+
+    /**
+     * Returns a paginated list of drafts. For each draft ID in the
+     * {@code users.drafts.list} response, fetches the full draft via
+     * {@code users.drafts.get(format=FULL)} and maps it to a
+     * {@link DraftDetailResult} via {@link GmailMessageMapper#toDraftDetailResult}.
+     *
+     * @param userId    the Gmail user identifier; typically {@code "me"}
+     * @param pageToken opaque pagination token, or null for the first page
+     * @param limit     maximum number of items to return (1–50)
+     * @return a {@link DraftListResult} with enriched drafts and pagination state
+     * @throws IOException on Gmail API communication failure
+     */
+    @Override
+    public DraftListResult listDrafts(String userId, String pageToken, int limit) throws IOException {
+        try {
+            Gmail gmail = getGmailService();
+
+            com.google.api.services.gmail.Gmail.Users.Drafts.List listRequest =
+                    gmail.users().drafts().list(userId)
+                            .setMaxResults((long) limit);
+            if (pageToken != null) {
+                listRequest.setPageToken(pageToken);
+            }
+
+            com.google.api.services.gmail.model.ListDraftsResponse listResponse = listRequest.execute();
+
+            java.util.List<com.google.api.services.gmail.model.Draft> draftStubs =
+                    listResponse.getDrafts();
+            String nextPageToken = listResponse.getNextPageToken();
+            Integer totalCount = listResponse.getResultSizeEstimate() != null
+                    ? listResponse.getResultSizeEstimate().intValue() : null;
+
+            java.util.List<DraftDetailResult> drafts = new java.util.ArrayList<>();
+            if (draftStubs != null) {
+                for (com.google.api.services.gmail.model.Draft stub : draftStubs) {
+                    com.google.api.services.gmail.model.Draft fullDraft =
+                            gmail.users().drafts().get(userId, stub.getId())
+                                    .setFormat("full")
+                                    .execute();
+                    drafts.add(gmailMessageMapper.toDraftDetailResult(fullDraft));
+                }
+            }
+
+            logger.info("Listed drafts: op=list, count={}", drafts.size());
+            return new DraftListResult(
+                    drafts.isEmpty() ? java.util.List.of() : java.util.List.copyOf(drafts),
+                    nextPageToken,
+                    totalCount
+            );
+
+        } catch (GeneralSecurityException e) {
+            throw new IOException("Security exception creating Gmail service", e);
+        }
+    }
+
+    /**
+     * Fetches the full content of a single draft via
+     * {@code users.drafts.get(format=FULL)} and maps it to a
+     * {@link DraftDetailResult}.
+     *
+     * @param userId  the Gmail user identifier; typically {@code "me"}
+     * @param draftId the Gmail draft identifier
+     * @return a {@link DraftDetailResult} with all fields populated
+     * @throws ResourceNotFoundException if the draft does not exist (Gmail 404)
+     * @throws IOException on Gmail API communication failure
+     */
+    @Override
+    public DraftDetailResult getDraft(String userId, String draftId) throws IOException {
+        try {
+            Gmail gmail = getGmailService();
+
+            com.google.api.services.gmail.model.Draft draft =
+                    gmail.users().drafts().get(userId, draftId)
+                            .setFormat("full")
+                            .execute();
+
+            logger.info("Got draft: op=get, draftId={}", draftId);
+            return gmailMessageMapper.toDraftDetailResult(draft);
+
+        } catch (GoogleJsonResponseException e) {
+            if (e.getStatusCode() == 404) {
+                throw new ResourceNotFoundException(
+                        "Draft not found: " + draftId, e);
+            }
+            logger.error("Gmail API error getting draft draftId={}: status={}, message={}",
+                    draftId, e.getStatusCode(), e.getMessage());
+            throw e;
+        } catch (GeneralSecurityException e) {
+            throw new IOException("Security exception creating Gmail service", e);
+        }
+    }
+
+    /**
+     * Permanently deletes the specified draft via {@code users.drafts.delete}.
+     *
+     * @param userId  the Gmail user identifier; typically {@code "me"}
+     * @param draftId the Gmail draft identifier
+     * @throws ResourceNotFoundException if the draft does not exist (Gmail 404)
+     * @throws IOException on Gmail API communication failure
+     */
+    @Override
+    public void deleteDraft(String userId, String draftId) throws IOException {
+        try {
+            Gmail gmail = getGmailService();
+
+            gmail.users().drafts().delete(userId, draftId).execute();
+            logger.info("Deleted draft: op=delete, draftId={}", draftId);
+
+        } catch (GoogleJsonResponseException e) {
+            if (e.getStatusCode() == 404) {
+                throw new ResourceNotFoundException(
+                        "Draft not found: " + draftId, e);
+            }
+            logger.error("Gmail API error deleting draft draftId={}: status={}, message={}",
+                    draftId, e.getStatusCode(), e.getMessage());
+            throw e;
+        } catch (GeneralSecurityException e) {
+            throw new IOException("Security exception creating Gmail service", e);
+        }
+    }
+
+    /**
+     * Replaces the content of the specified draft with the provided MimeMessage
+     * via {@code users.drafts.update}.
+     *
+     * @param userId      the Gmail user identifier; typically {@code "me"}
+     * @param draftId     the Gmail draft identifier
+     * @param mimeMessage the fully-constructed replacement MIME message
+     * @return a {@link DraftCreationResult} with the updated draft's identifiers
+     * @throws ResourceNotFoundException if the draft does not exist (Gmail 404)
+     * @throws IOException on Gmail API communication failure
+     */
+    @Override
+    public DraftCreationResult updateDraft(String userId, String draftId, MimeMessage mimeMessage) throws IOException {
+        try {
+            Gmail gmail = getGmailService();
+
+            ByteArrayOutputStream buffer = new ByteArrayOutputStream();
+            mimeMessage.writeTo(buffer);
+            String encodedRaw = Base64.getUrlEncoder().encodeToString(buffer.toByteArray());
+
+            com.google.api.services.gmail.model.Message rawMessage =
+                    new com.google.api.services.gmail.model.Message().setRaw(encodedRaw);
+            com.google.api.services.gmail.model.Draft draftWrapper =
+                    new com.google.api.services.gmail.model.Draft()
+                            .setId(draftId)
+                            .setMessage(rawMessage);
+
+            com.google.api.services.gmail.model.Draft updatedDraft =
+                    gmail.users().drafts().update(userId, draftId, draftWrapper).execute();
+
+            logger.info("Updated draft: op=update, draftId={}", draftId);
+            return gmailMessageMapper.toDraftCreationResult(updatedDraft);
+
+        } catch (GoogleJsonResponseException e) {
+            if (e.getStatusCode() == 404) {
+                throw new ResourceNotFoundException(
+                        "Draft not found: " + draftId, e);
+            }
+            logger.error("Gmail API error updating draft draftId={}: status={}, message={}",
+                    draftId, e.getStatusCode(), e.getMessage());
+            throw mapGmailSendError(e);
+        } catch (GeneralSecurityException e) {
+            throw new IOException("Security exception creating Gmail service", e);
+        } catch (jakarta.mail.MessagingException e) {
+            throw new IOException("Failed to serialize MimeMessage for draft update", e);
         }
     }
 

--- a/src/main/java/com/aucontraire/gmailbuddy/service/DraftDetailResult.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/service/DraftDetailResult.java
@@ -1,0 +1,35 @@
+package com.aucontraire.gmailbuddy.service;
+
+import com.aucontraire.gmailbuddy.dto.response.AttachmentMetadata;
+
+import java.util.List;
+
+/**
+ * Internal domain record holding the parsed contents of a single draft.
+ *
+ * <p>Returned by {@code GmailRepository.getDraft(...)} and used as the element
+ * type inside {@link DraftListResult}. Created by {@code GmailRepositoryImpl}
+ * (via {@code GmailMessageMapper.toDraftDetailResult}) after extracting fields
+ * from the Gmail SDK {@code Draft} object. Keeps Gmail SDK types out of
+ * service-layer signatures (Constitution II).</p>
+ *
+ * <p>List fields are never null — the mapper uses {@code List.of()} as fallback
+ * for missing recipients/attachments. String fields may be null when the
+ * underlying MIME header is absent (e.g., draft with no subject).</p>
+ *
+ * @see com.aucontraire.gmailbuddy.mapper.GmailMessageMapper#toDraftDetailResult
+ */
+public record DraftDetailResult(
+        String draftId,
+        String messageId,
+        String threadId,
+        List<String> to,
+        List<String> cc,
+        List<String> bcc,
+        String subject,
+        String snippet,
+        String body,
+        String bodyType,
+        String inReplyToMessageId,
+        List<AttachmentMetadata> attachments
+) {}

--- a/src/main/java/com/aucontraire/gmailbuddy/service/DraftListResult.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/service/DraftListResult.java
@@ -1,0 +1,26 @@
+package com.aucontraire.gmailbuddy.service;
+
+import java.util.List;
+
+/**
+ * Internal domain record returned by {@code GmailRepository.listDrafts(...)}
+ * holding a page of enriched draft results plus pagination state.
+ *
+ * <p>Each {@link DraftDetailResult} in {@code drafts} represents a single draft
+ * fully populated via {@code users.drafts.get(format=FULL)}. The repository
+ * performs the per-item enrichment before returning the list, so the
+ * service/controller layer does not need to make additional Gmail API calls.</p>
+ *
+ * <p>Mirrors the field-naming convention of {@link MessageListResult} (the
+ * older non-record equivalent for messages) and is the domain analog of
+ * {@link com.aucontraire.gmailbuddy.dto.response.DraftListResponse}.</p>
+ *
+ * @param drafts        per-item enriched draft results; {@code List.of()} for empty page
+ * @param nextPageToken token for the next page, or {@code null} when exhausted
+ * @param totalCount    {@code resultSizeEstimate} from Gmail API; may be {@code null}
+ */
+public record DraftListResult(
+        List<DraftDetailResult> drafts,
+        String nextPageToken,
+        Integer totalCount
+) {}

--- a/src/main/java/com/aucontraire/gmailbuddy/service/GmailService.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/service/GmailService.java
@@ -9,6 +9,7 @@ import com.aucontraire.gmailbuddy.exception.GmailApiException;
 import com.aucontraire.gmailbuddy.exception.MessageTooLargeException;
 import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
 import com.aucontraire.gmailbuddy.mapper.FilterCriteriaMapper;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.repository.GmailRepository;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaDTO;
 import com.google.api.services.gmail.model.FilterCriteria;
@@ -33,17 +34,20 @@ public class GmailService {
     private final GmailQueryBuilder gmailQueryBuilder;
     private final FilterCriteriaMapper filterCriteriaMapper;
     private final MimeMessageBuilder mimeMessageBuilder;
+    private final GmailMessageMapper gmailMessageMapper;
     private final GmailBuddyProperties properties;
     private final Logger logger = LoggerFactory.getLogger(GmailService.class);
 
     @Autowired
     public GmailService(GmailRepository gmailRepository, GmailQueryBuilder gmailQueryBuilder,
                         FilterCriteriaMapper filterCriteriaMapper, MimeMessageBuilder mimeMessageBuilder,
+                        GmailMessageMapper gmailMessageMapper,
                         GmailBuddyProperties properties) {
         this.gmailRepository = gmailRepository;
         this.gmailQueryBuilder = gmailQueryBuilder;
         this.filterCriteriaMapper = filterCriteriaMapper;
         this.mimeMessageBuilder = mimeMessageBuilder;
+        this.gmailMessageMapper = gmailMessageMapper;
         this.properties = properties;
     }
 
@@ -499,6 +503,125 @@ public class GmailService {
             logger.error("Failed to send message for user: {}", userId, e);
             throw new GmailApiException(
                     String.format("Failed to send message for user: %s", userId), e
+            );
+        }
+    }
+
+    // ---------------------------------------------------------------------------
+    // Draft CRUD — listDrafts, getDraft, deleteDraft, updateDraft
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Returns a paginated list of drafts for the specified user.
+     *
+     * @param userId    the Gmail user identifier; typically {@code "me"}
+     * @param pageToken opaque pagination token, or null for the first page
+     * @param limit     maximum number of items to return (1–50)
+     * @return a {@link DraftListResult} with enriched draft summaries
+     * @throws GmailApiException if the Gmail API returns an error
+     */
+    public DraftListResult listDrafts(String userId, String pageToken, int limit) throws GmailApiException {
+        try {
+            DraftListResult result = gmailRepository.listDrafts(userId, pageToken, limit);
+            logger.info("Draft operation: op=list, count={}", result.drafts().size());
+            return result;
+        } catch (IOException e) {
+            logger.error("Failed to list drafts for user: {}", userId, e);
+            throw new GmailApiException(
+                    String.format("Failed to list drafts for user: %s", userId), e
+            );
+        }
+    }
+
+    /**
+     * Returns the full content of the specified draft.
+     *
+     * @param userId  the Gmail user identifier; typically {@code "me"}
+     * @param draftId the Gmail draft identifier
+     * @return a {@link DraftDetailResult} with all parsed fields
+     * @throws ResourceNotFoundException if the draft does not exist
+     * @throws GmailApiException if the Gmail API returns an error
+     */
+    public DraftDetailResult getDraft(String userId, String draftId) throws GmailApiException {
+        try {
+            DraftDetailResult result = gmailRepository.getDraft(userId, draftId);
+            logger.info("Draft operation: op=get, draftId={}, attachmentCount={}",
+                    draftId, result.attachments().size());
+            return result;
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (IOException e) {
+            logger.error("Failed to get draft draftId={} for user: {}", draftId, userId, e);
+            throw new GmailApiException(
+                    String.format("Failed to get draft %s for user: %s", draftId, userId), e
+            );
+        }
+    }
+
+    /**
+     * Permanently deletes the specified draft.
+     *
+     * @param userId  the Gmail user identifier; typically {@code "me"}
+     * @param draftId the Gmail draft identifier
+     * @throws ResourceNotFoundException if the draft does not exist
+     * @throws GmailApiException if the Gmail API returns an error
+     */
+    public void deleteDraft(String userId, String draftId) throws GmailApiException {
+        try {
+            gmailRepository.deleteDraft(userId, draftId);
+            logger.info("Draft operation: op=delete, draftId={}", draftId);
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (IOException e) {
+            logger.error("Failed to delete draft draftId={} for user: {}", draftId, userId, e);
+            throw new GmailApiException(
+                    String.format("Failed to delete draft %s for user: %s", draftId, userId), e
+            );
+        }
+    }
+
+    /**
+     * Replaces the content of the specified draft. Performs a threading lookup when
+     * {@code dto.inReplyToMessageId()} is present, then builds a {@link MimeMessage}
+     * and calls the repository's {@code updateDraft}.
+     *
+     * @param userId  the Gmail user identifier; typically {@code "me"}
+     * @param draftId the Gmail draft identifier
+     * @param dto     the validated update request
+     * @return a {@link DraftDetailResult} reflecting the updated draft state
+     * @throws ResourceNotFoundException if the draft does not exist
+     * @throws GmailApiException if the Gmail API or MIME construction fails
+     */
+    public DraftDetailResult updateDraft(String userId, String draftId, SendMessageDTO dto) throws GmailApiException {
+        try {
+            boolean hasThreading = dto.inReplyToMessageId() != null;
+            OriginalMessageLookup lookup = null;
+            if (hasThreading) {
+                lookup = gmailRepository.getMessageHeaders(userId, dto.inReplyToMessageId());
+            }
+
+            MimeMessage mimeMessage = mimeMessageBuilder.build(dto, lookup);
+
+            DraftCreationResult updateResult = gmailRepository.updateDraft(userId, draftId, mimeMessage);
+
+            // Fetch the updated draft to return the full DraftDetailResult
+            DraftDetailResult result = gmailRepository.getDraft(userId, updateResult.draftId());
+
+            logger.info("Draft operation: op=update, draftId={}, attachmentCount={}, hasThreading={}",
+                    draftId, result.attachments().size(), hasThreading);
+            return result;
+
+        } catch (ResourceNotFoundException e) {
+            throw e;
+        } catch (MessageTooLargeException e) {
+            throw e;
+        } catch (MessagingException | java.io.UnsupportedEncodingException e) {
+            logger.error("Failed to build MimeMessage for draft update draftId={}: {}", draftId, e.getMessage());
+            throw new GmailApiException("Failed to construct email message for draft update", e);
+        } catch (IOException e) {
+            logger.error("Failed to update draft draftId={} for user: {}", draftId, userId, e);
+            throw new GmailApiException(
+                    String.format("Failed to update draft %s for user: %s", draftId, userId), e
             );
         }
     }

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/AttachmentControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/AttachmentControllerTest.java
@@ -1,6 +1,7 @@
 package com.aucontraire.gmailbuddy.controller;
 
 import com.aucontraire.gmailbuddy.exception.MessageTooLargeException;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
 import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
 import com.aucontraire.gmailbuddy.ratelimit.RateLimitInfo;
@@ -72,6 +73,7 @@ class AttachmentControllerTest {
     @MockitoBean private ResponseMapper responseMapper;
     @MockitoBean private RateLimitService rateLimitService;
     @MockitoBean private GmailQuotaEstimator gmailQuotaEstimator;
+    @MockitoBean private GmailMessageMapper gmailMessageMapper;
 
     // -------------------------------------------------------------------------
     // Helper: build the request body JSON

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/CreateDraftControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/CreateDraftControllerTest.java
@@ -2,6 +2,7 @@ package com.aucontraire.gmailbuddy.controller;
 
 import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
 import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
 import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
 import com.aucontraire.gmailbuddy.ratelimit.RateLimitService;
@@ -83,6 +84,9 @@ class CreateDraftControllerTest {
 
     @MockitoBean
     private GmailQuotaEstimator gmailQuotaEstimator;
+
+    @MockitoBean
+    private GmailMessageMapper gmailMessageMapper;
 
     // -------------------------------------------------------------------------
     // 201 Created — response body contract

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/GmailControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/GmailControllerTest.java
@@ -3,8 +3,13 @@ package com.aucontraire.gmailbuddy.controller;
 import com.aucontraire.gmailbuddy.GmailBuddyApplication;
 import com.aucontraire.gmailbuddy.config.TestTokenProviderConfiguration;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaDTO;
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+import com.aucontraire.gmailbuddy.exception.GmailApiException;
+import com.aucontraire.gmailbuddy.exception.OriginalMessageNotFoundException;
 import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
 import com.aucontraire.gmailbuddy.repository.GmailRepository;
+import com.aucontraire.gmailbuddy.service.DraftDetailResult;
+import com.aucontraire.gmailbuddy.service.DraftListResult;
 import com.aucontraire.gmailbuddy.service.GmailService;
 import com.aucontraire.gmailbuddy.service.MessageListResult;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,14 +32,19 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -115,5 +125,348 @@ public class GmailControllerTest {
         mockMvc.perform(get("/api/v1/gmail/messages/{messageId}/body", "12345")
                         .with(csrf()))
                 .andExpect(status().isNotFound());
+    }
+
+    // =========================================================================
+    // T010 — GET /api/v1/gmail/drafts — list drafts
+    // =========================================================================
+
+    @Test
+    public void listDrafts_200WithEmptyResults_returnsPaginatedShape() throws Exception {
+        DraftListResult emptyResult = new DraftListResult(List.of(), null, 0);
+        when(gmailService.listDrafts(eq("me"), any(), anyInt())).thenReturn(emptyResult);
+
+        mockMvc.perform(get("/api/v1/gmail/drafts")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.results").isArray())
+                .andExpect(jsonPath("$.results").isEmpty());
+    }
+
+    @Test
+    public void listDrafts_200WithResults_returnsListItems() throws Exception {
+        DraftDetailResult draft = new DraftDetailResult(
+                "draft-1", "msg-1", null,
+                List.of("to@example.com"), List.of(), List.of(),
+                "Test Subject", "snippet", "body", "text", null, List.of()
+        );
+        DraftListResult listResult = new DraftListResult(List.of(draft), "next-token", 1);
+        when(gmailService.listDrafts(eq("me"), any(), anyInt())).thenReturn(listResult);
+
+        mockMvc.perform(get("/api/v1/gmail/drafts")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.results").isArray())
+                .andExpect(jsonPath("$.results[0].id").value("draft-1"))
+                .andExpect(jsonPath("$.nextPageToken").value("next-token"))
+                .andExpect(jsonPath("$.totalCount").value(1));
+    }
+
+    @Test
+    public void listDrafts_400ForLimitExceedingMax() throws Exception {
+        mockMvc.perform(get("/api/v1/gmail/drafts")
+                        .param("limit", "51")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void listDrafts_400ForLimitZero() throws Exception {
+        mockMvc.perform(get("/api/v1/gmail/drafts")
+                        .param("limit", "0")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void listDrafts_401WhenUnauthenticated() throws Exception {
+        SecurityContextHolder.clearContext();
+
+        mockMvc.perform(get("/api/v1/gmail/drafts")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isFound());
+    }
+
+    @Test
+    public void listDrafts_502WhenGmailApiExceptionThrown() throws Exception {
+        when(gmailService.listDrafts(eq("me"), any(), anyInt()))
+                .thenThrow(new GmailApiException("Gmail API down", new java.io.IOException("timeout")));
+
+        mockMvc.perform(get("/api/v1/gmail/drafts")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadGateway());
+    }
+
+    // =========================================================================
+    // T010 — GET /api/v1/gmail/drafts/{draftId} — get draft
+    // =========================================================================
+
+    @Test
+    public void getDraft_200WithFullDraftDetailResponse() throws Exception {
+        DraftDetailResult detail = new DraftDetailResult(
+                "abc123", "msg-abc", "thread-1",
+                List.of("to@example.com"), List.of(), List.of(),
+                "Subject", "snippet", "<p>HTML body</p>", "html",
+                "in-reply-to", List.of()
+        );
+        when(gmailService.getDraft(eq("me"), eq("abc123"))).thenReturn(detail);
+
+        mockMvc.perform(get("/api/v1/gmail/drafts/{draftId}", "abc123")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("abc123"))
+                .andExpect(jsonPath("$.subject").value("Subject"))
+                .andExpect(jsonPath("$.bodyType").value("html"))
+                .andExpect(jsonPath("$.threadId").value("thread-1"))
+                .andExpect(jsonPath("$.inReplyToMessageId").value("in-reply-to"));
+    }
+
+    @Test
+    public void getDraft_404ForUnknownDraftId() throws Exception {
+        when(gmailService.getDraft(eq("me"), eq("deadbeef")))
+                .thenThrow(new ResourceNotFoundException("Draft not found"));
+
+        mockMvc.perform(get("/api/v1/gmail/drafts/{draftId}", "deadbeef")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void getDraft_400ForNonHexDraftId() throws Exception {
+        mockMvc.perform(get("/api/v1/gmail/drafts/{draftId}", "invalid_id!!!")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void getDraft_401WhenUnauthenticated() throws Exception {
+        SecurityContextHolder.clearContext();
+
+        mockMvc.perform(get("/api/v1/gmail/drafts/{draftId}", "abc123")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isFound());
+    }
+
+    @Test
+    public void getDraft_502WhenGmailApiException() throws Exception {
+        when(gmailService.getDraft(eq("me"), eq("abc123")))
+                .thenThrow(new GmailApiException("Gmail error", new java.io.IOException("io")));
+
+        mockMvc.perform(get("/api/v1/gmail/drafts/{draftId}", "abc123")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadGateway());
+    }
+
+    // =========================================================================
+    // T023 — DELETE /api/v1/gmail/drafts/{draftId} — delete draft
+    // =========================================================================
+
+    @Test
+    public void deleteDraft_204NoContentOnSuccess() throws Exception {
+        // doNothing is default for void mocks
+        mockMvc.perform(delete("/api/v1/gmail/drafts/{draftId}", "abc123")
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    public void deleteDraft_404ForUnknownDraftId() throws Exception {
+        doThrow(new ResourceNotFoundException("Draft not found"))
+                .when(gmailService).deleteDraft(eq("me"), eq("deadbeef"));
+
+        mockMvc.perform(delete("/api/v1/gmail/drafts/{draftId}", "deadbeef")
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void deleteDraft_400ForInvalidDraftId() throws Exception {
+        mockMvc.perform(delete("/api/v1/gmail/drafts/{draftId}", "invalid!!!")
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void deleteDraft_401WhenUnauthenticated() throws Exception {
+        SecurityContextHolder.clearContext();
+
+        mockMvc.perform(delete("/api/v1/gmail/drafts/{draftId}", "abc123")
+                        .with(csrf()))
+                .andExpect(status().isFound());
+    }
+
+    @Test
+    public void deleteDraft_502WhenGmailApiException() throws Exception {
+        doThrow(new GmailApiException("Gmail error", new java.io.IOException("io")))
+                .when(gmailService).deleteDraft(eq("me"), eq("abc123"));
+
+        mockMvc.perform(delete("/api/v1/gmail/drafts/{draftId}", "abc123")
+                        .with(csrf()))
+                .andExpect(status().isBadGateway());
+    }
+
+    // =========================================================================
+    // T033 — PUT /api/v1/gmail/drafts/{draftId} — update draft
+    // =========================================================================
+
+    @Test
+    public void updateDraft_200WithUpdatedDraftDetailResponse() throws Exception {
+        DraftDetailResult updated = new DraftDetailResult(
+                "abc123", "msg-1", null,
+                List.of("to@example.com"), List.of(), List.of(),
+                "Updated Subject", "snippet", "Updated body", "text",
+                null, List.of()
+        );
+        when(gmailService.updateDraft(eq("me"), eq("abc123"), any(SendMessageDTO.class)))
+                .thenReturn(updated);
+
+        String requestBody = """
+                {
+                  "to": ["to@example.com"],
+                  "cc": [],
+                  "bcc": [],
+                  "subject": "Updated Subject",
+                  "body": "Updated body",
+                  "attachments": []
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/gmail/drafts/{draftId}", "abc123")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value("abc123"))
+                .andExpect(jsonPath("$.subject").value("Updated Subject"));
+    }
+
+    @Test
+    public void updateDraft_404ForUnknownDraftId() throws Exception {
+        when(gmailService.updateDraft(eq("me"), eq("deadbeef"), any(SendMessageDTO.class)))
+                .thenThrow(new ResourceNotFoundException("Draft not found"));
+
+        String requestBody = """
+                {
+                  "to": ["to@example.com"],
+                  "cc": [],
+                  "bcc": [],
+                  "subject": "Subject",
+                  "body": "Body",
+                  "attachments": []
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/gmail/drafts/{draftId}", "deadbeef")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void updateDraft_400ForInvalidDraftId() throws Exception {
+        String requestBody = """
+                {
+                  "to": ["to@example.com"],
+                  "cc": [],
+                  "bcc": [],
+                  "subject": "Subject",
+                  "body": "Body",
+                  "attachments": []
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/gmail/drafts/{draftId}", "invalid!!!")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void updateDraft_422ForOriginalMessageNotFound() throws Exception {
+        when(gmailService.updateDraft(eq("me"), eq("abc123"), any(SendMessageDTO.class)))
+                .thenThrow(new OriginalMessageNotFoundException("inReplyTo target not found"));
+
+        String requestBody = """
+                {
+                  "to": ["to@example.com"],
+                  "cc": [],
+                  "bcc": [],
+                  "subject": "Re: Subject",
+                  "body": "Reply body",
+                  "attachments": [],
+                  "inReplyToMessageId": "1a2b3c4d5e6f7890"
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/gmail/drafts/{draftId}", "abc123")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isUnprocessableEntity());
+    }
+
+    @Test
+    public void updateDraft_401WhenUnauthenticated() throws Exception {
+        SecurityContextHolder.clearContext();
+
+        String requestBody = """
+                {
+                  "to": ["to@example.com"],
+                  "cc": [],
+                  "bcc": [],
+                  "subject": "Subject",
+                  "body": "Body",
+                  "attachments": []
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/gmail/drafts/{draftId}", "abc123")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isFound());
+    }
+
+    @Test
+    public void updateDraft_502WhenGmailApiException() throws Exception {
+        when(gmailService.updateDraft(eq("me"), eq("abc123"), any(SendMessageDTO.class)))
+                .thenThrow(new GmailApiException("Gmail API error", new java.io.IOException("io")));
+
+        String requestBody = """
+                {
+                  "to": ["to@example.com"],
+                  "cc": [],
+                  "bcc": [],
+                  "subject": "Subject",
+                  "body": "Body",
+                  "attachments": []
+                }
+                """;
+
+        mockMvc.perform(put("/api/v1/gmail/drafts/{draftId}", "abc123")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(requestBody)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadGateway());
     }
 }

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/SendDraftControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/SendDraftControllerTest.java
@@ -1,6 +1,7 @@
 package com.aucontraire.gmailbuddy.controller;
 
 import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
 import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
 import com.aucontraire.gmailbuddy.ratelimit.RateLimitService;
@@ -72,6 +73,9 @@ class SendDraftControllerTest {
 
     @MockitoBean
     private GmailQuotaEstimator gmailQuotaEstimator;
+
+    @MockitoBean
+    private GmailMessageMapper gmailMessageMapper;
 
     // -------------------------------------------------------------------------
     // 200 OK — correct status code (NOT 201)

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/SendMessageControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/SendMessageControllerTest.java
@@ -4,6 +4,7 @@ import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
 import com.aucontraire.gmailbuddy.exception.InvalidRecipientException;
 import com.aucontraire.gmailbuddy.exception.MessageTooLargeException;
 import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
 import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
 import com.aucontraire.gmailbuddy.ratelimit.RateLimitService;
@@ -86,6 +87,9 @@ class SendMessageControllerTest {
 
     @MockitoBean
     private GmailQuotaEstimator gmailQuotaEstimator;
+
+    @MockitoBean
+    private GmailMessageMapper gmailMessageMapper;
 
     // -------------------------------------------------------------------------
     // 201 Created — correct status code

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/ThreadingControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/ThreadingControllerTest.java
@@ -5,6 +5,7 @@ import com.aucontraire.gmailbuddy.config.ResponseHeaderFilter;
 import com.aucontraire.gmailbuddy.exception.AuthorizationException;
 import com.aucontraire.gmailbuddy.exception.GmailApiException;
 import com.aucontraire.gmailbuddy.exception.OriginalMessageNotFoundException;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
 import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
 import com.aucontraire.gmailbuddy.ratelimit.RateLimitInfo;
@@ -90,6 +91,7 @@ class ThreadingControllerTest {
     @MockitoBean private ResponseMapper responseMapper;
     @MockitoBean private RateLimitService rateLimitService;
     @MockitoBean private GmailQuotaEstimator gmailQuotaEstimator;
+    @MockitoBean private GmailMessageMapper gmailMessageMapper;
 
     // -------------------------------------------------------------------------
     // Helper: build the minimal valid send-message JSON with threading fields

--- a/src/test/java/com/aucontraire/gmailbuddy/dto/SendMessageDTOThreadingAttachmentTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/dto/SendMessageDTOThreadingAttachmentTest.java
@@ -2,6 +2,7 @@ package com.aucontraire.gmailbuddy.dto;
 
 import com.aucontraire.gmailbuddy.controller.GmailController;
 import com.aucontraire.gmailbuddy.fixture.AttachmentFixtures;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
 import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
 import com.aucontraire.gmailbuddy.ratelimit.RateLimitService;
@@ -203,6 +204,9 @@ class SendMessageDTOThreadingAttachmentTest {
 
         @MockitoBean
         private GmailQuotaEstimator gmailQuotaEstimator;
+
+        @MockitoBean
+        private GmailMessageMapper gmailMessageMapper;
 
         // -------------------------------------------------------------------------
         // threadId — @Pattern validation via controller endpoint

--- a/src/test/java/com/aucontraire/gmailbuddy/integration/DraftLifecycleIntegrationTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/integration/DraftLifecycleIntegrationTest.java
@@ -1,0 +1,438 @@
+package com.aucontraire.gmailbuddy.integration;
+
+import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
+import com.aucontraire.gmailbuddy.repository.GmailRepository;
+import com.aucontraire.gmailbuddy.service.DraftDetailResult;
+import com.aucontraire.gmailbuddy.service.DraftListResult;
+import com.aucontraire.gmailbuddy.service.GmailService;
+import com.aucontraire.gmailbuddy.service.GoogleTokenValidator;
+import com.aucontraire.gmailbuddy.service.SentMessageResult;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests verifying FR-001a (sent draft absent from list) and the
+ * analogous delete-then-list scenario end-to-end through the controller layer
+ * (T043).
+ *
+ * <p>Two nested classes correspond to the two lifecycle scenarios:</p>
+ * <ol>
+ *   <li><strong>Send lifecycle</strong>: list (present) → get (200) → send (200)
+ *       → list (absent) → get (404). Verifies FR-001a: a draft is permanently
+ *       removed from the drafts list after it is sent.</li>
+ *   <li><strong>Delete lifecycle</strong>: list (present) → delete (204)
+ *       → list (absent) → get (404). Verifies the symmetric guarantee for the
+ *       DELETE endpoint — a hard-deleted draft is absent from subsequent list
+ *       and get calls.</li>
+ * </ol>
+ *
+ * <p>The full Spring application context is loaded ({@code @SpringBootTest +
+ * @AutoConfigureMockMvc}) so the real controller routing, filter chain, and
+ * exception handling ({@code GlobalExceptionHandler}) run. {@code GmailService}
+ * is mocked at the service boundary — the mocked service is configured with
+ * sequential stubs (using Mockito's {@code thenReturn(...).thenReturn(...)})
+ * to simulate state changes across HTTP calls without a real Gmail API.</p>
+ *
+ * <p>Draft identifiers must match {@code [A-Za-z0-9_-]{1,128}} (Gmail's opaque
+ * format — letter-prefix + alphanumeric, e.g., {@code "r9068706262700056809"}).
+ * The {@code @Pattern} constraint on the {@code {draftId}} path variable rejects
+ * path-traversal characters before reaching the service.</p>
+ *
+ * <p>The {@code @WithMockUser} annotation injects a mock Spring Security
+ * principal so the OAuth2 redirect is bypassed. This mirrors the browser-session
+ * path used in {@code CreateDraftIntegrationTest} and
+ * {@code SendDraftIntegrationTest}.</p>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("Draft CRUD endpoints — lifecycle integration (FR-001a) (T043)")
+class DraftLifecycleIntegrationTest {
+
+    // ---------------------------------------------------------------------------
+    // Constants
+    // ---------------------------------------------------------------------------
+
+    private static final String DRAFTS_BASE       = "/api/v1/gmail/drafts";
+    // IDs matching @Pattern(regexp = "[A-Za-z0-9_-]{1,128}") — Gmail's opaque draft format
+    private static final String DRAFT_ID          = "abc123def456";
+    private static final String DRAFT_MESSAGE_ID  = "19a2b3c4d5e60001";
+    private static final String SENT_MESSAGE_ID   = "19a2b3c4d5e60002";
+    private static final String THREAD_ID         = "19a2b3c4d5e60001";
+
+    // ---------------------------------------------------------------------------
+    // Spring-managed beans
+    // ---------------------------------------------------------------------------
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private GmailService gmailService;
+
+    @MockitoBean
+    private GmailRepository gmailRepository;
+
+    @MockitoBean
+    private GoogleTokenValidator tokenValidator;
+
+    @BeforeEach
+    void resetMocks() {
+        reset(gmailService, gmailRepository, tokenValidator);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Returns a realistic {@link DraftDetailResult} with all fields populated,
+     * representing a draft that exists before any state-changing operation.
+     */
+    private DraftDetailResult existingDraft() {
+        return new DraftDetailResult(
+                DRAFT_ID,
+                DRAFT_MESSAGE_ID,
+                THREAD_ID,
+                List.of("recruiter@example.com"),
+                List.of(),
+                List.of(),
+                "Re: Software Engineer Application",
+                "Hi there, following up on my application...",
+                "Hi there, following up on my application for the role.",
+                "text",
+                null,
+                List.of()
+        );
+    }
+
+    /**
+     * Returns a {@link DraftListResult} containing the single draft — models the
+     * state before the send or delete operation.
+     */
+    private DraftListResult listWithDraft() {
+        return new DraftListResult(List.of(existingDraft()), null, 1);
+    }
+
+    /**
+     * Returns a {@link DraftListResult} with an empty list — models the state
+     * AFTER the draft has been sent or deleted.
+     */
+    private DraftListResult emptyList() {
+        return new DraftListResult(List.of(), null, 0);
+    }
+
+    // ===========================================================================
+    // Nested: Send lifecycle (FR-001a)
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("Send lifecycle: list → get → send → list (absent) → get (404)")
+    class SendLifecycleTests {
+
+        /**
+         * Full send lifecycle sequence exercised in a single test method to verify
+         * the causal chain: after {@code POST /drafts/{id}/send} succeeds, the draft
+         * is absent from a subsequent {@code GET /drafts} and yields 404 on
+         * {@code GET /drafts/{id}}.
+         *
+         * <p>Mock strategy:</p>
+         * <ul>
+         *   <li>{@code listDrafts}: first call returns the draft; second call (post-send)
+         *       returns an empty list.</li>
+         *   <li>{@code getDraft}: first call returns the full draft; second call (post-send)
+         *       throws {@code ResourceNotFoundException}.</li>
+         *   <li>{@code sendDraft}: single call returns a {@link SentMessageResult}.</li>
+         * </ul>
+         */
+        @Test
+        @WithMockUser
+        @DisplayName("sendDraft_thenList_draftIsAbsentFromList_FR001a")
+        void sendDraft_thenList_draftIsAbsentFromList_FR001a() throws Exception {
+            // Arrange — sequential stub: first listDrafts returns the draft, second returns empty.
+            when(gmailService.listDrafts(anyString(), isNull(), anyInt()))
+                    .thenReturn(listWithDraft())
+                    .thenReturn(emptyList());
+
+            // Arrange — sequential stub: first getDraft returns the draft, second throws 404.
+            when(gmailService.getDraft(anyString(), anyString()))
+                    .thenReturn(existingDraft())
+                    .thenThrow(new ResourceNotFoundException(
+                            "Draft not found: " + DRAFT_ID, "DRAFT_NOT_FOUND"));
+
+            // Arrange — sendDraft stub.
+            when(gmailService.sendDraft(anyString(), anyString()))
+                    .thenReturn(new SentMessageResult(SENT_MESSAGE_ID, THREAD_ID));
+
+            // Step 1: GET /drafts → 200, draft-001 present in results
+            mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.results").isArray())
+                    .andExpect(jsonPath("$.results.length()").value(1))
+                    .andExpect(jsonPath("$.results[0].id").value(DRAFT_ID));
+
+            // Step 2: GET /drafts/{id} → 200, full DraftDetailResponse
+            mockMvc.perform(get(DRAFTS_BASE + "/{draftId}", DRAFT_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(DRAFT_ID))
+                    .andExpect(jsonPath("$.to[0]").value("recruiter@example.com"))
+                    .andExpect(jsonPath("$.subject").value("Re: Software Engineer Application"));
+
+            // Step 3: POST /drafts/{id}/send → 200 (state transition, no Location header)
+            mockMvc.perform(post(DRAFTS_BASE + "/{draftId}/send", DRAFT_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.messageId").value(SENT_MESSAGE_ID))
+                    .andExpect(jsonPath("$.status").value("SENT"));
+
+            // Step 4: GET /drafts → 200, draft absent (FR-001a: sent draft removed from list)
+            mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.results").isArray())
+                    .andExpect(jsonPath("$.results.length()").value(0));
+
+            // Step 5: GET /drafts/{id} → 404 with /problems/resource-not-found
+            mockMvc.perform(get(DRAFTS_BASE + "/{draftId}", DRAFT_ID))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.type").value("/problems/resource-not-found"));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("sendDraft_thenGetById_returns404WithCorrectProblemType")
+        void sendDraft_thenGetById_returns404WithCorrectProblemType() throws Exception {
+            // Arrange: getDraft is already absent (draft was sent before this request)
+            when(gmailService.getDraft(anyString(), anyString()))
+                    .thenThrow(new ResourceNotFoundException(
+                            "Draft not found: " + DRAFT_ID, "DRAFT_NOT_FOUND"));
+
+            // Act & Assert: 404 response carries the RFC 7807 problem type
+            mockMvc.perform(get(DRAFTS_BASE + "/{draftId}", DRAFT_ID))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.type").value("/problems/resource-not-found"))
+                    .andExpect(jsonPath("$.status").value(404));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("listDrafts_afterSend_returnsEmptyResultsNotA404")
+        void listDrafts_afterSend_returnsEmptyResultsNotA404() throws Exception {
+            // Arrange: after send, list returns empty — NOT a 404. An empty queue is
+            // represented as 200 OK with results=[] per spec (FR-001a note).
+            when(gmailService.listDrafts(anyString(), isNull(), anyInt()))
+                    .thenReturn(emptyList());
+
+            // Act & Assert
+            mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.results").isArray())
+                    .andExpect(jsonPath("$.results.length()").value(0))
+                    .andExpect(jsonPath("$.nextPageToken").doesNotExist());
+        }
+    }
+
+    // ===========================================================================
+    // Nested: Delete lifecycle (FR-001a analogue)
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("Delete lifecycle: list → delete → list (absent) → get (404)")
+    class DeleteLifecycleTests {
+
+        /**
+         * Full delete lifecycle sequence: list confirms presence, delete succeeds,
+         * subsequent list confirms absence, subsequent get returns 404.
+         *
+         * <p>Mock strategy:</p>
+         * <ul>
+         *   <li>{@code listDrafts}: first call returns the draft; second call (post-delete)
+         *       returns an empty list.</li>
+         *   <li>{@code deleteDraft}: void method — doNothing() on first call.</li>
+         *   <li>{@code getDraft}: call after delete throws {@code ResourceNotFoundException}.</li>
+         * </ul>
+         */
+        @Test
+        @WithMockUser
+        @DisplayName("deleteDraft_thenList_draftIsAbsentFromList")
+        void deleteDraft_thenList_draftIsAbsentFromList() throws Exception {
+            // Arrange — sequential listDrafts: first returns the draft, second returns empty.
+            when(gmailService.listDrafts(anyString(), isNull(), anyInt()))
+                    .thenReturn(listWithDraft())
+                    .thenReturn(emptyList());
+
+            // Arrange — deleteDraft: void method; Mockito default is doNothing().
+            doNothing().when(gmailService).deleteDraft(anyString(), anyString());
+
+            // Arrange — getDraft after delete throws 404.
+            when(gmailService.getDraft(anyString(), anyString()))
+                    .thenThrow(new ResourceNotFoundException(
+                            "Draft not found: " + DRAFT_ID, "DRAFT_NOT_FOUND"));
+
+            // Step 1: GET /drafts → 200, draft present
+            mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.results.length()").value(1))
+                    .andExpect(jsonPath("$.results[0].id").value(DRAFT_ID));
+
+            // Step 2: DELETE /drafts/{id} → 204 No Content, empty response body
+            mockMvc.perform(delete(DRAFTS_BASE + "/{draftId}", DRAFT_ID))
+                    .andExpect(status().isNoContent());
+
+            // Step 3: GET /drafts → 200, draft absent
+            mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.results").isArray())
+                    .andExpect(jsonPath("$.results.length()").value(0));
+
+            // Step 4: GET /drafts/{id} → 404 with /problems/resource-not-found
+            mockMvc.perform(get(DRAFTS_BASE + "/{draftId}", DRAFT_ID))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.type").value("/problems/resource-not-found"));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("deleteDraft_success_returns204WithEmptyBody")
+        void deleteDraft_success_returns204WithEmptyBody() throws Exception {
+            // Arrange: Mockito default for void is doNothing()
+            doNothing().when(gmailService).deleteDraft(anyString(), anyString());
+
+            // Act & Assert: 204 No Content — no body
+            mockMvc.perform(delete(DRAFTS_BASE + "/{draftId}", DRAFT_ID))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("deleteDraft_alreadyDeleted_returns404WithCorrectProblemType")
+        void deleteDraft_alreadyDeleted_returns404WithCorrectProblemType() throws Exception {
+            // Arrange: deleteDraft throws ResourceNotFoundException (idempotent per FR-011 —
+            // same 404 response whether never-existed or already-deleted).
+            doThrow(new ResourceNotFoundException(
+                    "Draft not found: " + DRAFT_ID, "DRAFT_NOT_FOUND"))
+                    .when(gmailService).deleteDraft(anyString(), anyString());
+
+            // Act & Assert
+            mockMvc.perform(delete(DRAFTS_BASE + "/{draftId}", DRAFT_ID))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.type").value("/problems/resource-not-found"))
+                    .andExpect(jsonPath("$.status").value(404));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("listDrafts_afterDelete_returnsEmptyResultsNotA404")
+        void listDrafts_afterDelete_returnsEmptyResultsNotA404() throws Exception {
+            // Arrange: empty queue after delete is 200 OK with results=[], not 404
+            when(gmailService.listDrafts(anyString(), isNull(), anyInt()))
+                    .thenReturn(emptyList());
+
+            // Act & Assert
+            mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.results").isArray())
+                    .andExpect(jsonPath("$.results.length()").value(0));
+        }
+    }
+
+    // ===========================================================================
+    // Nested: Cross-lifecycle — combined send + delete scenarios
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("Cross-lifecycle: sequential state verification")
+    class CrossLifecycleTests {
+
+        @Test
+        @WithMockUser
+        @DisplayName("listDrafts_multipleItems_thenDeleteOne_listShrinks")
+        void listDrafts_multipleItems_thenDeleteOne_listShrinks() throws Exception {
+            // Arrange: initial list has two drafts; after delete one remains.
+            DraftDetailResult draft1 = new DraftDetailResult(
+                    DRAFT_ID, DRAFT_MESSAGE_ID, THREAD_ID,
+                    List.of("alice@example.com"), List.of(), List.of(),
+                    "Draft 1", "snippet 1", "body 1", "text", null, List.of()
+            );
+            String secondDraftId = "cafe0000beef0001";
+            DraftDetailResult draft2 = new DraftDetailResult(
+                    secondDraftId, "cafe0000beef0002", "cafe0000beef0001",
+                    List.of("bob@example.com"), List.of(), List.of(),
+                    "Draft 2", "snippet 2", "body 2", "text", null, List.of()
+            );
+
+            DraftListResult twoItems  = new DraftListResult(List.of(draft1, draft2), null, 2);
+            DraftListResult oneItem   = new DraftListResult(List.of(draft2), null, 1);
+
+            when(gmailService.listDrafts(anyString(), isNull(), anyInt()))
+                    .thenReturn(twoItems)
+                    .thenReturn(oneItem);
+            doNothing().when(gmailService).deleteDraft(anyString(), anyString());
+
+            // Step 1: list → 2 items
+            mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.results.length()").value(2));
+
+            // Step 2: delete the first draft
+            mockMvc.perform(delete(DRAFTS_BASE + "/{draftId}", DRAFT_ID))
+                    .andExpect(status().isNoContent());
+
+            // Step 3: list → 1 item (the second draft remains)
+            mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.results.length()").value(1))
+                    .andExpect(jsonPath("$.results[0].id").value(secondDraftId));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("getDraft_beforeAndAfterSend_200ThenCorrect404ProblemType")
+        void getDraft_beforeAndAfterSend_200ThenCorrect404ProblemType() throws Exception {
+            // Arrange: first getDraft succeeds; second (post-send) throws 404.
+            when(gmailService.getDraft(anyString(), anyString()))
+                    .thenReturn(existingDraft())
+                    .thenThrow(new ResourceNotFoundException(
+                            "Draft not found: " + DRAFT_ID, "DRAFT_NOT_FOUND"));
+            when(gmailService.sendDraft(anyString(), anyString()))
+                    .thenReturn(new SentMessageResult(SENT_MESSAGE_ID, THREAD_ID));
+
+            // Step 1: GET /drafts/{id} → 200
+            mockMvc.perform(get(DRAFTS_BASE + "/{draftId}", DRAFT_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.id").value(DRAFT_ID));
+
+            // Step 2: POST /drafts/{id}/send → 200
+            mockMvc.perform(post(DRAFTS_BASE + "/{draftId}/send", DRAFT_ID))
+                    .andExpect(status().isOk());
+
+            // Step 3: GET /drafts/{id} → 404 with /problems/resource-not-found
+            mockMvc.perform(get(DRAFTS_BASE + "/{draftId}", DRAFT_ID))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.type").value("/problems/resource-not-found"))
+                    .andExpect(jsonPath("$.status").value(404));
+        }
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/integration/DraftsRateLimitHeadersIntegrationTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/integration/DraftsRateLimitHeadersIntegrationTest.java
@@ -1,0 +1,514 @@
+package com.aucontraire.gmailbuddy.integration;
+
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
+import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.repository.GmailRepository;
+import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.DraftDetailResult;
+import com.aucontraire.gmailbuddy.service.DraftListResult;
+import com.aucontraire.gmailbuddy.service.GmailService;
+import com.aucontraire.gmailbuddy.service.GoogleTokenValidator;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Integration tests verifying FR-019 ({@code X-Gmail-Quota-Used}) and FR-019a
+ * ({@code X-RateLimit-Limit}, {@code X-RateLimit-Remaining}, {@code X-RateLimit-Reset})
+ * response headers are present on all 4 new draft CRUD endpoints (T042).
+ *
+ * <p>Uses the full Spring application context ({@code @SpringBootTest +
+ * @AutoConfigureMockMvc}) so the real {@code RateLimitInterceptor} and
+ * {@code ResponseHeaderFilter} participate in the filter chain — unlike
+ * {@code @WebMvcTest} which loads only the web slice and would not wire those
+ * components automatically.</p>
+ *
+ * <p>{@code GmailService} is mocked at the service boundary so no real Gmail
+ * API calls are made. {@code GmailRepository} is also mocked to satisfy Spring
+ * context wiring. The test uses {@code @WithMockUser} (browser-session path)
+ * for simplicity — the header-verification concern is authentication-agnostic,
+ * and the session path exercises the same filter chain.</p>
+ *
+ * <p>Quota values under test:</p>
+ * <ul>
+ *   <li>GET /drafts — pre-execution estimate {@code 1 + DEFAULT_LIMIT * 5};
+ *       post-execution overwrite from controller: {@code 1 + N * 5} where N is
+ *       the actual item count returned by the mocked service</li>
+ *   <li>GET /drafts/{id} — 5 (from {@code GmailQuotaEstimator.estimateGetDraftQuota()})</li>
+ *   <li>DELETE /drafts/{id} — 10 (from {@code estimateDeleteDraftQuota()})</li>
+ *   <li>PUT /drafts/{id} — 15 (from {@code estimateUpdateDraftQuota()}, no threading)</li>
+ * </ul>
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@DisplayName("Draft CRUD endpoints — rate-limit and quota response headers (T042)")
+class DraftsRateLimitHeadersIntegrationTest {
+
+    // ---------------------------------------------------------------------------
+    // Constants
+    // ---------------------------------------------------------------------------
+
+    private static final String DRAFTS_BASE     = "/api/v1/gmail/drafts";
+    // Draft ID matching @Pattern(regexp = "[A-Za-z0-9_-]{1,128}") on the path variable.
+    // Gmail draft IDs use letter-prefixed alphanumeric format (e.g., "r9068706262700056809").
+    private static final String VALID_DRAFT_ID  = "abc123def456";
+    private static final String DRAFT_MESSAGE_ID = "19a2b3c4d5e6f700";
+    private static final String THREAD_ID        = "19a2b3c4d5e6f700";
+
+    // ---------------------------------------------------------------------------
+    // Spring-managed beans
+    // ---------------------------------------------------------------------------
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private GmailService gmailService;
+
+    @MockitoBean
+    private GmailRepository gmailRepository;
+
+    @MockitoBean
+    private GoogleTokenValidator tokenValidator;
+
+    @BeforeEach
+    void resetMocks() {
+        reset(gmailService, gmailRepository, tokenValidator);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Helpers — shared stub builders
+    // ---------------------------------------------------------------------------
+
+    /**
+     * Returns a {@link DraftDetailResult} with all required fields populated.
+     * Used both as the GET /drafts/{id} service stub and as the element type
+     * inside the GET /drafts list stub.
+     */
+    private DraftDetailResult stubDraftDetail() {
+        return new DraftDetailResult(
+                VALID_DRAFT_ID,
+                DRAFT_MESSAGE_ID,
+                THREAD_ID,
+                List.of("recruiter@example.com"),
+                List.of(),
+                List.of(),
+                "Re: Software Engineer Application",
+                "Hi there, following up on my application...",
+                "Hi there, following up on my application for the role.",
+                "text",
+                null,
+                List.of()
+        );
+    }
+
+    // ===========================================================================
+    // Nested: GET /drafts — list endpoint
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("GET /api/v1/gmail/drafts — list drafts")
+    class ListDraftsHeaderTests {
+
+        @Test
+        @WithMockUser
+        @DisplayName("listDrafts_success_allFourRateLimitHeadersPresent")
+        void listDrafts_success_allFourRateLimitHeadersPresent() throws Exception {
+            // Arrange: service returns a single-item list. Controller rewrites quota to
+            // 1 + 1*5 = 6 after execution.
+            DraftDetailResult item = stubDraftDetail();
+            DraftListResult listResult = new DraftListResult(List.of(item), null, 1);
+            when(gmailService.listDrafts(anyString(), any(), anyInt())).thenReturn(listResult);
+
+            // Act & Assert
+            mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andExpect(header().exists("X-Gmail-Quota-Used"))
+                    .andExpect(header().exists("X-RateLimit-Limit"))
+                    .andExpect(header().exists("X-RateLimit-Remaining"))
+                    .andExpect(header().exists("X-RateLimit-Reset"));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("listDrafts_oneItem_quotaHeaderReflectsActualOneItemCost")
+        void listDrafts_oneItem_quotaHeaderReflectsActualOneItemCost() throws Exception {
+            // Arrange: 1 draft returned → actual quota = 1 + 1*5 = 6
+            DraftDetailResult item = stubDraftDetail();
+            DraftListResult listResult = new DraftListResult(List.of(item), null, 1);
+            when(gmailService.listDrafts(anyString(), any(), anyInt())).thenReturn(listResult);
+
+            // Act
+            MvcResult result = mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // Assert: controller updates ATTR_GMAIL_QUOTA_USED post-execution to 1 + N*5
+            String quotaUsed = result.getResponse().getHeader("X-Gmail-Quota-Used");
+            assertThat(quotaUsed).isNotNull();
+            assertThat(Integer.parseInt(quotaUsed)).isEqualTo(6); // 1 + 1*5
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("listDrafts_emptyList_quotaHeaderReflectsBaseListCostOnly")
+        void listDrafts_emptyList_quotaHeaderReflectsBaseListCostOnly() throws Exception {
+            // Arrange: 0 drafts returned → actual quota = 1 + 0*5 = 1
+            DraftListResult emptyResult = new DraftListResult(List.of(), null, 0);
+            when(gmailService.listDrafts(anyString(), any(), anyInt())).thenReturn(emptyResult);
+
+            // Act
+            MvcResult result = mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // Assert
+            String quotaUsed = result.getResponse().getHeader("X-Gmail-Quota-Used");
+            assertThat(quotaUsed).isNotNull();
+            assertThat(Integer.parseInt(quotaUsed)).isEqualTo(1); // 1 + 0*5
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("listDrafts_threeItems_quotaHeaderReflectsActualThreeItemCost")
+        void listDrafts_threeItems_quotaHeaderReflectsActualThreeItemCost() throws Exception {
+            // Arrange: 3 drafts returned → actual quota = 1 + 3*5 = 16
+            DraftDetailResult item = stubDraftDetail();
+            DraftListResult listResult = new DraftListResult(List.of(item, item, item), null, 3);
+            when(gmailService.listDrafts(anyString(), any(), anyInt())).thenReturn(listResult);
+
+            // Act
+            MvcResult result = mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // Assert
+            String quotaUsed = result.getResponse().getHeader("X-Gmail-Quota-Used");
+            assertThat(quotaUsed).isNotNull();
+            assertThat(Integer.parseInt(quotaUsed)).isEqualTo(16); // 1 + 3*5
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("listDrafts_invalidLimit_400ErrorResponseStillHasRateLimitHeaders")
+        void listDrafts_invalidLimit_400ErrorResponseStillHasRateLimitHeaders() throws Exception {
+            // Arrange: limit=0 violates @Min(1) — service should never be called.
+            // Act & Assert: even 400 error responses carry the rate-limit headers
+            // because RateLimitInterceptor runs in preHandle (before validation).
+            mockMvc.perform(get(DRAFTS_BASE).param("limit", "0"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(header().exists("X-RateLimit-Limit"))
+                    .andExpect(header().exists("X-RateLimit-Remaining"))
+                    .andExpect(header().exists("X-RateLimit-Reset"));
+        }
+    }
+
+    // ===========================================================================
+    // Nested: GET /drafts/{draftId} — get endpoint
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("GET /api/v1/gmail/drafts/{draftId} — get draft detail")
+    class GetDraftHeaderTests {
+
+        @Test
+        @WithMockUser
+        @DisplayName("getDraft_success_allFourRateLimitHeadersPresent")
+        void getDraft_success_allFourRateLimitHeadersPresent() throws Exception {
+            // Arrange
+            when(gmailService.getDraft(anyString(), anyString())).thenReturn(stubDraftDetail());
+
+            // Act & Assert
+            mockMvc.perform(get(DRAFTS_BASE + "/{draftId}", VALID_DRAFT_ID))
+                    .andExpect(status().isOk())
+                    .andExpect(header().exists("X-Gmail-Quota-Used"))
+                    .andExpect(header().exists("X-RateLimit-Limit"))
+                    .andExpect(header().exists("X-RateLimit-Remaining"))
+                    .andExpect(header().exists("X-RateLimit-Reset"));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("getDraft_success_quotaHeaderIs5")
+        void getDraft_success_quotaHeaderIs5() throws Exception {
+            // Arrange
+            when(gmailService.getDraft(anyString(), anyString())).thenReturn(stubDraftDetail());
+
+            // Act
+            MvcResult result = mockMvc.perform(get(DRAFTS_BASE + "/{draftId}", VALID_DRAFT_ID))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // Assert: GmailQuotaEstimator.estimateGetDraftQuota() == 5
+            String quotaUsed = result.getResponse().getHeader("X-Gmail-Quota-Used");
+            assertThat(quotaUsed).isNotNull();
+            assertThat(Integer.parseInt(quotaUsed)).isEqualTo(5);
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("getDraft_invalidIdFormat_400ErrorResponseStillHasRateLimitHeaders")
+        void getDraft_invalidIdFormat_400ErrorResponseStillHasRateLimitHeaders() throws Exception {
+            // Arrange: ID contains '.' which violates @Pattern([A-Za-z0-9_-]{1,128}).
+            // Period is URL-safe (not stripped by URI parsing), so the validator sees the full string.
+            // Act & Assert
+            mockMvc.perform(get(DRAFTS_BASE + "/bad.id"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(header().exists("X-RateLimit-Limit"))
+                    .andExpect(header().exists("X-RateLimit-Remaining"))
+                    .andExpect(header().exists("X-RateLimit-Reset"));
+        }
+    }
+
+    // ===========================================================================
+    // Nested: DELETE /drafts/{draftId} — delete endpoint
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("DELETE /api/v1/gmail/drafts/{draftId} — delete draft")
+    class DeleteDraftHeaderTests {
+
+        @Test
+        @WithMockUser
+        @DisplayName("deleteDraft_success_allFourRateLimitHeadersPresent")
+        void deleteDraft_success_allFourRateLimitHeadersPresent() throws Exception {
+            // Arrange: deleteDraft() is void — no stub return value needed.
+            // The doNothing() default for void methods is automatically applied by Mockito.
+
+            // Act & Assert
+            mockMvc.perform(delete(DRAFTS_BASE + "/{draftId}", VALID_DRAFT_ID))
+                    .andExpect(status().isNoContent())
+                    .andExpect(header().exists("X-Gmail-Quota-Used"))
+                    .andExpect(header().exists("X-RateLimit-Limit"))
+                    .andExpect(header().exists("X-RateLimit-Remaining"))
+                    .andExpect(header().exists("X-RateLimit-Reset"));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("deleteDraft_success_quotaHeaderIs10")
+        void deleteDraft_success_quotaHeaderIs10() throws Exception {
+            // Act
+            MvcResult result = mockMvc.perform(delete(DRAFTS_BASE + "/{draftId}", VALID_DRAFT_ID))
+                    .andExpect(status().isNoContent())
+                    .andReturn();
+
+            // Assert: GmailQuotaEstimator.estimateDeleteDraftQuota() == 10
+            String quotaUsed = result.getResponse().getHeader("X-Gmail-Quota-Used");
+            assertThat(quotaUsed).isNotNull();
+            assertThat(Integer.parseInt(quotaUsed)).isEqualTo(10);
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("deleteDraft_invalidIdFormat_400ErrorResponseStillHasRateLimitHeaders")
+        void deleteDraft_invalidIdFormat_400ErrorResponseStillHasRateLimitHeaders() throws Exception {
+            // Act & Assert
+            mockMvc.perform(delete(DRAFTS_BASE + "/bad.id"))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(header().exists("X-RateLimit-Limit"))
+                    .andExpect(header().exists("X-RateLimit-Remaining"))
+                    .andExpect(header().exists("X-RateLimit-Reset"));
+        }
+    }
+
+    // ===========================================================================
+    // Nested: PUT /drafts/{draftId} — update endpoint
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("PUT /api/v1/gmail/drafts/{draftId} — update draft")
+    class UpdateDraftHeaderTests {
+
+        @Test
+        @WithMockUser
+        @DisplayName("updateDraft_noThreading_allFourRateLimitHeadersPresent")
+        void updateDraft_noThreading_allFourRateLimitHeadersPresent() throws Exception {
+            // Arrange
+            when(gmailService.updateDraft(anyString(), anyString(), any(SendMessageDTO.class)))
+                    .thenReturn(stubDraftDetail());
+
+            SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+            String body = objectMapper.writeValueAsString(dto);
+
+            // Act & Assert
+            mockMvc.perform(put(DRAFTS_BASE + "/{draftId}", VALID_DRAFT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isOk())
+                    .andExpect(header().exists("X-Gmail-Quota-Used"))
+                    .andExpect(header().exists("X-RateLimit-Limit"))
+                    .andExpect(header().exists("X-RateLimit-Remaining"))
+                    .andExpect(header().exists("X-RateLimit-Reset"));
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("updateDraft_noThreading_quotaHeaderIs15")
+        void updateDraft_noThreading_quotaHeaderIs15() throws Exception {
+            // Arrange
+            when(gmailService.updateDraft(anyString(), anyString(), any(SendMessageDTO.class)))
+                    .thenReturn(stubDraftDetail());
+
+            SendMessageDTO dto = SendMessageRequestFixtures.validSingleRecipient();
+            String body = objectMapper.writeValueAsString(dto);
+
+            // Act
+            MvcResult result = mockMvc.perform(put(DRAFTS_BASE + "/{draftId}", VALID_DRAFT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // Assert: GmailQuotaEstimator.estimateUpdateDraftQuota() == 15 (no threading)
+            String quotaUsed = result.getResponse().getHeader("X-Gmail-Quota-Used");
+            assertThat(quotaUsed).isNotNull();
+            assertThat(Integer.parseInt(quotaUsed)).isEqualTo(15);
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("updateDraft_withInReplyToMessageId_quotaHeaderIs20")
+        void updateDraft_withInReplyToMessageId_quotaHeaderIs20() throws Exception {
+            // Arrange: inReplyToMessageId present → controller sets quota to 20 (15+5)
+            // post-execution per data-model §13.
+            when(gmailService.updateDraft(anyString(), anyString(), any(SendMessageDTO.class)))
+                    .thenReturn(stubDraftDetail());
+
+            // Build a DTO with inReplyToMessageId set to a valid hex message ID.
+            SendMessageDTO threadedDto = new SendMessageDTO(
+                    List.of("recruiter@example.com"),
+                    null,
+                    null,
+                    "Re: Software Engineer Application",
+                    "Following up on your message.",
+                    "text",
+                    THREAD_ID,
+                    DRAFT_MESSAGE_ID,   // inReplyToMessageId — non-null triggers +5 quota
+                    null
+            );
+            String body = objectMapper.writeValueAsString(threadedDto);
+
+            // Act
+            MvcResult result = mockMvc.perform(put(DRAFTS_BASE + "/{draftId}", VALID_DRAFT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // Assert: controller sets ATTR_GMAIL_QUOTA_USED = 20 when inReplyToMessageId present.
+            String quotaUsed = result.getResponse().getHeader("X-Gmail-Quota-Used");
+            assertThat(quotaUsed).isNotNull();
+            assertThat(Integer.parseInt(quotaUsed)).isEqualTo(20);
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("updateDraft_missingToRecipient_400ErrorResponseStillHasRateLimitHeaders")
+        void updateDraft_missingToRecipient_400ErrorResponseStillHasRateLimitHeaders() throws Exception {
+            // Arrange: empty `to` list triggers @NotEmpty constraint → 400 before service is called.
+            SendMessageDTO invalidDto = SendMessageRequestFixtures.invalidEmptyToList();
+            String body = objectMapper.writeValueAsString(invalidDto);
+
+            // Act & Assert: RateLimitInterceptor.preHandle() runs before DispatcherServlet binding,
+            // so the rate-limit headers must still be present even on a 400 validation error.
+            mockMvc.perform(put(DRAFTS_BASE + "/{draftId}", VALID_DRAFT_ID)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(body))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(header().exists("X-RateLimit-Limit"))
+                    .andExpect(header().exists("X-RateLimit-Remaining"))
+                    .andExpect(header().exists("X-RateLimit-Reset"));
+        }
+    }
+
+    // ===========================================================================
+    // Nested: Cross-cutting — RateLimit header value sanity
+    // ===========================================================================
+
+    @Nested
+    @DisplayName("Rate-limit header value sanity across endpoints")
+    class RateLimitHeaderValueSanityTests {
+
+        @Test
+        @WithMockUser
+        @DisplayName("rateLimitHeaders_limitsAreNonNegativeIntegers_onListDrafts")
+        void rateLimitHeaders_limitsAreNonNegativeIntegers_onListDrafts() throws Exception {
+            // Arrange
+            DraftListResult emptyResult = new DraftListResult(List.of(), null, 0);
+            when(gmailService.listDrafts(anyString(), any(), anyInt())).thenReturn(emptyResult);
+
+            // Act
+            MvcResult result = mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // Assert: header values are parseable integers and non-negative
+            String limit     = result.getResponse().getHeader("X-RateLimit-Limit");
+            String remaining = result.getResponse().getHeader("X-RateLimit-Remaining");
+            String reset     = result.getResponse().getHeader("X-RateLimit-Reset");
+
+            assertThat(limit).isNotNull();
+            assertThat(remaining).isNotNull();
+            assertThat(reset).isNotNull();
+
+            assertThat(Integer.parseInt(limit)).isGreaterThan(0);
+            assertThat(Integer.parseInt(remaining)).isGreaterThanOrEqualTo(0);
+            assertThat(Long.parseLong(reset)).isGreaterThan(0L);
+        }
+
+        @Test
+        @WithMockUser
+        @DisplayName("rateLimitHeaders_remainingDecrementsAcrossConsecutiveRequests")
+        void rateLimitHeaders_remainingDecrementsAcrossConsecutiveRequests() throws Exception {
+            // Arrange
+            DraftListResult emptyResult = new DraftListResult(List.of(), null, 0);
+            when(gmailService.listDrafts(anyString(), any(), anyInt())).thenReturn(emptyResult);
+
+            // Act: first request
+            MvcResult first = mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // Act: second request
+            MvcResult second = mockMvc.perform(get(DRAFTS_BASE))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            // Assert: remaining on second request should be <= remaining on first request
+            int remainingFirst  = Integer.parseInt(first.getResponse().getHeader("X-RateLimit-Remaining"));
+            int remainingSecond = Integer.parseInt(second.getResponse().getHeader("X-RateLimit-Remaining"));
+
+            assertThat(remainingSecond).isLessThanOrEqualTo(remainingFirst);
+        }
+    }
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/mapper/GmailMessageMapperTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/mapper/GmailMessageMapperTest.java
@@ -1,11 +1,24 @@
 package com.aucontraire.gmailbuddy.mapper;
 
+import com.aucontraire.gmailbuddy.dto.response.AttachmentMetadata;
+import com.aucontraire.gmailbuddy.dto.response.DraftDetailResponse;
+import com.aucontraire.gmailbuddy.dto.response.DraftListItem;
+import com.aucontraire.gmailbuddy.dto.response.DraftListResponse;
 import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.DraftDetailResult;
+import com.aucontraire.gmailbuddy.service.DraftListResult;
 import com.aucontraire.gmailbuddy.service.SentMessageResult;
 import com.google.api.services.gmail.model.Draft;
 import com.google.api.services.gmail.model.Message;
+import com.google.api.services.gmail.model.MessagePart;
+import com.google.api.services.gmail.model.MessagePartBody;
+import com.google.api.services.gmail.model.MessagePartHeader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
@@ -213,5 +226,389 @@ class GmailMessageMapperTest {
         assertThat(result.draftId()).isEqualTo("draft-msg-no-thread");
         assertThat(result.messageId()).isEqualTo("msg-no-thread");
         assertThat(result.threadId()).isNull();
+    }
+
+    // =========================================================================
+    // T007 — toDraftDetailResult(Draft) tests
+    // =========================================================================
+
+    // Helper: encode string to base64url for building test payloads
+    private String encodeBase64Url(String text) {
+        return Base64.getUrlEncoder().encodeToString(text.getBytes(StandardCharsets.UTF_8));
+    }
+
+    // Helper: build a MessagePart with optional mimeType, body data, filename
+    private MessagePart buildBodyPart(String mimeType, String bodyText) {
+        MessagePart part = new MessagePart();
+        part.setMimeType(mimeType);
+        MessagePartBody body = new MessagePartBody();
+        body.setData(encodeBase64Url(bodyText));
+        part.setBody(body);
+        return part;
+    }
+
+    private MessagePart buildAttachmentPart(String filename, String mimeType, long sizeBytes) {
+        MessagePart part = new MessagePart();
+        part.setMimeType(mimeType);
+        part.setFilename(filename);
+        MessagePartBody body = new MessagePartBody();
+        body.setSize((int) sizeBytes);
+        part.setBody(body);
+        return part;
+    }
+
+    private MessagePartHeader header(String name, String value) {
+        MessagePartHeader h = new MessagePartHeader();
+        h.setName(name);
+        h.setValue(value);
+        return h;
+    }
+
+    private Draft buildFullDraft(String draftId, String messageId, String threadId,
+                                  String snippet, List<MessagePartHeader> headers,
+                                  List<MessagePart> subParts) {
+        MessagePart payload = new MessagePart();
+        payload.setMimeType("multipart/mixed");
+        payload.setHeaders(headers);
+        payload.setParts(subParts);
+
+        Message message = new Message();
+        message.setId(messageId);
+        message.setThreadId(threadId);
+        message.setSnippet(snippet);
+        message.setPayload(payload);
+
+        Draft draft = new Draft();
+        draft.setId(draftId);
+        draft.setMessage(message);
+        return draft;
+    }
+
+    @Test
+    void toDraftDetailResult_fullDraft_allFieldsPopulated() {
+        String bodyText = "Hello, Sarah!";
+        Draft draft = buildFullDraft(
+                "draft-001", "msg-001", "thread-001", "Hello, Sarah!",
+                List.of(
+                        header("To", "sarah@example.com"),
+                        header("Cc", "cc1@example.com"),
+                        header("Bcc", "bcc1@example.com"),
+                        header("Subject", "Test Subject")
+                ),
+                List.of(buildBodyPart("text/plain", bodyText))
+        );
+
+        DraftDetailResult result = mapper.toDraftDetailResult(draft);
+
+        assertThat(result.draftId()).isEqualTo("draft-001");
+        assertThat(result.messageId()).isEqualTo("msg-001");
+        assertThat(result.threadId()).isEqualTo("thread-001");
+        assertThat(result.snippet()).isEqualTo("Hello, Sarah!");
+        assertThat(result.to()).containsExactly("sarah@example.com");
+        assertThat(result.cc()).containsExactly("cc1@example.com");
+        assertThat(result.bcc()).containsExactly("bcc1@example.com");
+        assertThat(result.subject()).isEqualTo("Test Subject");
+        assertThat(result.body()).isEqualTo(bodyText);
+        assertThat(result.bodyType()).isEqualTo("text");
+        assertThat(result.inReplyToMessageId()).isNull();
+        assertThat(result.attachments()).isEmpty();
+    }
+
+    @Test
+    void toDraftDetailResult_missingSubject_subjectIsNull() {
+        Draft draft = buildFullDraft(
+                "draft-002", "msg-002", null, null,
+                List.of(header("To", "test@example.com")),
+                List.of(buildBodyPart("text/plain", "Body text"))
+        );
+
+        DraftDetailResult result = mapper.toDraftDetailResult(draft);
+
+        assertThat(result.subject()).isNull();
+    }
+
+    @Test
+    void toDraftDetailResult_missingRecipients_returnsEmptyLists() {
+        Draft draft = buildFullDraft(
+                "draft-003", "msg-003", null, null,
+                List.of(header("Subject", "No recipients")),
+                List.of(buildBodyPart("text/plain", "body"))
+        );
+
+        DraftDetailResult result = mapper.toDraftDetailResult(draft);
+
+        assertThat(result.to()).isNotNull().isEmpty();
+        assertThat(result.cc()).isNotNull().isEmpty();
+        assertThat(result.bcc()).isNotNull().isEmpty();
+    }
+
+    @Test
+    void toDraftDetailResult_threadedDraft_setsThreadIdAndInReplyToMessageId() {
+        Draft draft = buildFullDraft(
+                "draft-004", "msg-004", "thread-abc", null,
+                List.of(
+                        header("To", "test@example.com"),
+                        header("In-Reply-To", "<original-msg-id@mail.gmail.com>")
+                ),
+                List.of(buildBodyPart("text/plain", "reply body"))
+        );
+
+        DraftDetailResult result = mapper.toDraftDetailResult(draft);
+
+        assertThat(result.threadId()).isEqualTo("thread-abc");
+        // Angle brackets must be stripped
+        assertThat(result.inReplyToMessageId()).isEqualTo("original-msg-id@mail.gmail.com");
+    }
+
+    @Test
+    void toDraftDetailResult_htmlBodyPart_bodyTypeIsHtml() {
+        String htmlContent = "<p>Hello <b>World</b></p>";
+        Draft draft = buildFullDraft(
+                "draft-005", "msg-005", null, null,
+                List.of(header("To", "test@example.com")),
+                List.of(buildBodyPart("text/html", htmlContent))
+        );
+
+        DraftDetailResult result = mapper.toDraftDetailResult(draft);
+
+        assertThat(result.bodyType()).isEqualTo("html");
+        assertThat(result.body()).isEqualTo(htmlContent);
+    }
+
+    @Test
+    void toDraftDetailResult_textBodyPart_bodyTypeIsText() {
+        String plainContent = "Plain text body";
+        Draft draft = buildFullDraft(
+                "draft-006", "msg-006", null, null,
+                List.of(header("To", "test@example.com")),
+                List.of(buildBodyPart("text/plain", plainContent))
+        );
+
+        DraftDetailResult result = mapper.toDraftDetailResult(draft);
+
+        assertThat(result.bodyType()).isEqualTo("text");
+        assertThat(result.body()).isEqualTo(plainContent);
+    }
+
+    @Test
+    void toDraftDetailResult_htmlWinsOverPlain_whenBothPresent() {
+        String htmlContent = "<p>HTML body</p>";
+        String plainContent = "Plain body";
+
+        MessagePart payload = new MessagePart();
+        payload.setMimeType("multipart/alternative");
+        payload.setHeaders(List.of(header("To", "test@example.com")));
+        payload.setParts(List.of(
+                buildBodyPart("text/plain", plainContent),
+                buildBodyPart("text/html", htmlContent)
+        ));
+
+        Message message = new Message();
+        message.setId("msg-007");
+        message.setPayload(payload);
+
+        Draft draft = new Draft();
+        draft.setId("draft-007");
+        draft.setMessage(message);
+
+        DraftDetailResult result = mapper.toDraftDetailResult(draft);
+
+        assertThat(result.bodyType()).isEqualTo("html");
+        assertThat(result.body()).isEqualTo(htmlContent);
+    }
+
+    @Test
+    void toDraftDetailResult_withAttachments_attachmentCountMatchesAndMetadataCorrect() {
+        Draft draft = buildFullDraft(
+                "draft-008", "msg-008", null, null,
+                List.of(header("To", "test@example.com")),
+                List.of(
+                        buildBodyPart("text/plain", "body"),
+                        buildAttachmentPart("resume.pdf", "application/pdf", 245760L),
+                        buildAttachmentPart("cover-letter.docx",
+                                "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                                102400L)
+                )
+        );
+
+        DraftDetailResult result = mapper.toDraftDetailResult(draft);
+
+        assertThat(result.attachments()).hasSize(2);
+        assertThat(result.attachments().get(0).filename()).isEqualTo("resume.pdf");
+        assertThat(result.attachments().get(0).mimeType()).isEqualTo("application/pdf");
+        assertThat(result.attachments().get(0).sizeBytes()).isEqualTo(245760L);
+        assertThat(result.attachments().get(1).filename()).isEqualTo("cover-letter.docx");
+    }
+
+    @Test
+    void toDraftDetailResult_base64UrlBodyDecoding_roundTripsCorrectly() {
+        String originalText = "Hello World! Special chars: é à ü";
+        String encodedBody = Base64.getUrlEncoder()
+                .encodeToString(originalText.getBytes(StandardCharsets.UTF_8));
+
+        MessagePart bodyPart = new MessagePart();
+        bodyPart.setMimeType("text/plain");
+        MessagePartBody body = new MessagePartBody();
+        body.setData(encodedBody);
+        bodyPart.setBody(body);
+
+        Draft draft = buildFullDraft(
+                "draft-009", "msg-009", null, null,
+                List.of(header("To", "test@example.com")),
+                List.of(bodyPart)
+        );
+
+        DraftDetailResult result = mapper.toDraftDetailResult(draft);
+
+        assertThat(result.body()).isEqualTo(originalText);
+    }
+
+    @Test
+    void toDraftDetailResult_nullMessage_returnsMinimalResult() {
+        Draft draft = new Draft();
+        draft.setId("draft-010");
+        // message is null
+
+        DraftDetailResult result = mapper.toDraftDetailResult(draft);
+
+        assertThat(result.draftId()).isEqualTo("draft-010");
+        assertThat(result.messageId()).isNull();
+        assertThat(result.to()).isNotNull().isEmpty();
+        assertThat(result.attachments()).isNotNull().isEmpty();
+    }
+
+    // =========================================================================
+    // T007 — toDraftListItem(DraftDetailResult) tests
+    // =========================================================================
+
+    @Test
+    void toDraftListItem_projection_picksCorrectSubsetOfFields() {
+        List<AttachmentMetadata> attachments = List.of(
+                new AttachmentMetadata("file.pdf", "application/pdf", 1024L)
+        );
+        DraftDetailResult detail = new DraftDetailResult(
+                "draft-id-1", "msg-1", "thread-1",
+                List.of("to@example.com"), List.of("cc@example.com"), List.of(),
+                "Test Subject", "A snippet", "body text", "text",
+                "in-reply-to-id", attachments
+        );
+
+        DraftListItem item = mapper.toDraftListItem(detail);
+
+        assertThat(item.id()).isEqualTo("draft-id-1");
+        assertThat(item.to()).containsExactly("to@example.com");
+        assertThat(item.cc()).containsExactly("cc@example.com");
+        assertThat(item.bcc()).isEmpty();
+        assertThat(item.subject()).isEqualTo("Test Subject");
+        assertThat(item.snippet()).isEqualTo("A snippet");
+        assertThat(item.threadId()).isEqualTo("thread-1");
+        assertThat(item.attachmentCount()).isEqualTo(1);
+    }
+
+    @Test
+    void toDraftListItem_attachmentCountMatchesAttachmentsSize() {
+        List<AttachmentMetadata> attachments = List.of(
+                new AttachmentMetadata("a.pdf", "application/pdf", 100L),
+                new AttachmentMetadata("b.pdf", "application/pdf", 200L),
+                new AttachmentMetadata("c.pdf", "application/pdf", 300L)
+        );
+        DraftDetailResult detail = new DraftDetailResult(
+                "d1", "m1", null, List.of(), List.of(), List.of(),
+                null, null, null, "text", null, attachments
+        );
+
+        DraftListItem item = mapper.toDraftListItem(detail);
+
+        assertThat(item.attachmentCount()).isEqualTo(3);
+    }
+
+    // =========================================================================
+    // T007 — toDraftDetailResponse(DraftDetailResult) tests
+    // =========================================================================
+
+    @Test
+    void toDraftDetailResponse_oneToOneFieldMapping_allFieldsTransferred() {
+        List<AttachmentMetadata> attachments = List.of(
+                new AttachmentMetadata("doc.pdf", "application/pdf", 5000L)
+        );
+        DraftDetailResult detail = new DraftDetailResult(
+                "draft-resp-1", "msg-resp-1", "thread-resp-1",
+                List.of("recipient@example.com"), List.of(), List.of(),
+                "Subject line", "snippet", "<p>HTML body</p>", "html",
+                "in-reply-to-ref", attachments
+        );
+
+        DraftDetailResponse response = mapper.toDraftDetailResponse(detail);
+
+        assertThat(response.id()).isEqualTo("draft-resp-1");
+        assertThat(response.to()).containsExactly("recipient@example.com");
+        assertThat(response.cc()).isEmpty();
+        assertThat(response.bcc()).isEmpty();
+        assertThat(response.subject()).isEqualTo("Subject line");
+        assertThat(response.body()).isEqualTo("<p>HTML body</p>");
+        assertThat(response.bodyType()).isEqualTo("html");
+        assertThat(response.threadId()).isEqualTo("thread-resp-1");
+        assertThat(response.inReplyToMessageId()).isEqualTo("in-reply-to-ref");
+        assertThat(response.attachments()).hasSize(1);
+    }
+
+    @Test
+    void toDraftDetailResponse_nullableFieldsPassThroughAsNull() {
+        DraftDetailResult detail = new DraftDetailResult(
+                "draft-null-fields", "msg-n", null,
+                List.of(), List.of(), List.of(),
+                null, null, null, "text", null, List.of()
+        );
+
+        DraftDetailResponse response = mapper.toDraftDetailResponse(detail);
+
+        assertThat(response.subject()).isNull();
+        assertThat(response.body()).isNull();
+        assertThat(response.threadId()).isNull();
+        assertThat(response.inReplyToMessageId()).isNull();
+    }
+
+    // =========================================================================
+    // T007 — toDraftListResponse(DraftListResult) tests
+    // =========================================================================
+
+    @Test
+    void toDraftListResponse_eachDraftProjectedViaToDraftListItem() {
+        List<DraftDetailResult> drafts = List.of(
+                new DraftDetailResult("d1", "m1", null, List.of("a@b.com"), List.of(), List.of(),
+                        "S1", "snip1", null, "text", null, List.of()),
+                new DraftDetailResult("d2", "m2", "t2", List.of("c@d.com"), List.of(), List.of(),
+                        "S2", "snip2", null, "text", null, List.of())
+        );
+        DraftListResult listResult = new DraftListResult(drafts, "token-abc", 42);
+
+        DraftListResponse response = mapper.toDraftListResponse(listResult);
+
+        assertThat(response.results()).hasSize(2);
+        assertThat(response.results().get(0).id()).isEqualTo("d1");
+        assertThat(response.results().get(1).id()).isEqualTo("d2");
+        assertThat(response.nextPageToken()).isEqualTo("token-abc");
+        assertThat(response.totalCount()).isEqualTo(42);
+    }
+
+    @Test
+    void toDraftListResponse_emptyDraftList_returnsEmptyResults() {
+        DraftListResult listResult = new DraftListResult(List.of(), null, null);
+
+        DraftListResponse response = mapper.toDraftListResponse(listResult);
+
+        assertThat(response.results()).isNotNull().isEmpty();
+        assertThat(response.nextPageToken()).isNull();
+        assertThat(response.totalCount()).isNull();
+    }
+
+    @Test
+    void toDraftListResponse_nextPageTokenAndTotalCountPassThrough() {
+        DraftListResult listResult = new DraftListResult(List.of(), "page-token-xyz", 99);
+
+        DraftListResponse response = mapper.toDraftListResponse(listResult);
+
+        assertThat(response.nextPageToken()).isEqualTo("page-token-xyz");
+        assertThat(response.totalCount()).isEqualTo(99);
     }
 }

--- a/src/test/java/com/aucontraire/gmailbuddy/ratelimit/GmailQuotaEstimatorTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/ratelimit/GmailQuotaEstimatorTest.java
@@ -174,4 +174,53 @@ class GmailQuotaEstimatorTest {
         assertEquals(15, quota,
                 "Threaded create draft should cost 15 quota units (5 lookup + 10 draft create)");
     }
+
+    // -------------------------------------------------------------------------
+    // T008 — Draft CRUD quota methods
+    // -------------------------------------------------------------------------
+
+    @Test
+    void estimateListDraftsQuota_zeroItems_returnsOne() {
+        // 1 (list call) + 0 * 5 = 1
+        assertEquals(1, estimator.estimateListDraftsQuota(0),
+                "Zero items: only the list call costs 1 unit");
+    }
+
+    @Test
+    void estimateListDraftsQuota_tenItems_returns51() {
+        // 1 + 10 * 5 = 51
+        assertEquals(51, estimator.estimateListDraftsQuota(10));
+    }
+
+    @Test
+    void estimateListDraftsQuota_twentyFiveItems_returns126() {
+        // 1 + 25 * 5 = 126
+        assertEquals(126, estimator.estimateListDraftsQuota(25));
+    }
+
+    @Test
+    void estimateListDraftsQuota_fiftyItems_returns251() {
+        // 1 + 50 * 5 = 251
+        assertEquals(251, estimator.estimateListDraftsQuota(50));
+    }
+
+    @Test
+    void estimateGetDraftQuota_returnsFive() {
+        assertEquals(5, estimator.estimateGetDraftQuota(),
+                "Get draft should cost 5 quota units");
+    }
+
+    // T021 — Delete draft quota
+    @Test
+    void estimateDeleteDraftQuota_returnsTen() {
+        assertEquals(10, estimator.estimateDeleteDraftQuota(),
+                "Delete draft should cost 10 quota units");
+    }
+
+    // T031 — Update draft quota
+    @Test
+    void estimateUpdateDraftQuota_returnsFifteen() {
+        assertEquals(15, estimator.estimateUpdateDraftQuota(),
+                "Update draft should cost 15 quota units");
+    }
 }

--- a/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceAttachmentTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceAttachmentTest.java
@@ -9,6 +9,7 @@ import com.aucontraire.gmailbuddy.dto.Attachment;
 import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
 import com.aucontraire.gmailbuddy.exception.MessageTooLargeException;
 import com.aucontraire.gmailbuddy.mapper.FilterCriteriaMapper;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.repository.GmailRepository;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
@@ -139,13 +140,15 @@ class GmailServiceAttachmentTest {
     /** Builds a GmailService with the mocked MimeMessageBuilder (for size-check tests). */
     private GmailService serviceWithMockedBuilder() {
         return new GmailService(
-                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder, properties);
+                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder,
+                mock(GmailMessageMapper.class), properties);
     }
 
     /** Builds a GmailService with the REAL MimeMessageBuilder (for log-compliance tests). */
     private GmailService serviceWithRealBuilder() {
         return new GmailService(
-                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, realMimeMessageBuilder, properties);
+                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, realMimeMessageBuilder,
+                mock(GmailMessageMapper.class), properties);
     }
 
     /** Creates a small base64 payload that will exceed the given byte limit. */

--- a/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceCreateDraftTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceCreateDraftTest.java
@@ -5,6 +5,7 @@ import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
 import com.aucontraire.gmailbuddy.exception.GmailApiException;
 import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
 import com.aucontraire.gmailbuddy.mapper.FilterCriteriaMapper;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.repository.GmailRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
@@ -72,7 +73,8 @@ class GmailServiceCreateDraftTest {
         when(properties.send()).thenReturn(send);
         when(send.maxTotalPayloadSize()).thenReturn(DataSize.ofMegabytes(25));
         gmailService = new GmailService(
-                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder, properties);
+                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder,
+                mock(GmailMessageMapper.class), properties);
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceSendDraftTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceSendDraftTest.java
@@ -3,6 +3,7 @@ package com.aucontraire.gmailbuddy.service;
 import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
 import com.aucontraire.gmailbuddy.exception.GmailApiException;
 import com.aucontraire.gmailbuddy.mapper.FilterCriteriaMapper;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.repository.GmailRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -62,7 +63,8 @@ class GmailServiceSendDraftTest {
         when(properties.send()).thenReturn(send);
         when(send.maxTotalPayloadSize()).thenReturn(DataSize.ofMegabytes(25));
         gmailService = new GmailService(
-                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder, properties);
+                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder,
+                mock(GmailMessageMapper.class), properties);
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceSendMessageTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceSendMessageTest.java
@@ -5,6 +5,7 @@ import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
 import com.aucontraire.gmailbuddy.exception.GmailApiException;
 import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
 import com.aucontraire.gmailbuddy.mapper.FilterCriteriaMapper;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.repository.GmailRepository;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
@@ -72,7 +73,8 @@ class GmailServiceSendMessageTest {
         when(properties.send()).thenReturn(send);
         when(send.maxTotalPayloadSize()).thenReturn(DataSize.ofMegabytes(25));
         gmailService = new GmailService(
-                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder, properties);
+                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder,
+                mock(GmailMessageMapper.class), properties);
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceTest.java
@@ -4,10 +4,16 @@ import com.aucontraire.gmailbuddy.config.GmailBuddyProperties;
 import com.aucontraire.gmailbuddy.dto.DeleteResult;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaDTO;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaWithLabelsDTO;
+import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
 import com.aucontraire.gmailbuddy.exception.GmailApiException;
 import com.aucontraire.gmailbuddy.exception.ResourceNotFoundException;
 import com.aucontraire.gmailbuddy.mapper.FilterCriteriaMapper;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.repository.GmailRepository;
+import com.aucontraire.gmailbuddy.service.DraftCreationResult;
+import com.aucontraire.gmailbuddy.service.DraftDetailResult;
+import com.aucontraire.gmailbuddy.service.DraftListResult;
+import com.aucontraire.gmailbuddy.service.OriginalMessageLookup;
 import com.google.api.services.gmail.model.FilterCriteria;
 import com.google.api.services.gmail.model.Message;
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +40,7 @@ class GmailServiceTest {
     private GmailQueryBuilder gmailQueryBuilder;
     private FilterCriteriaMapper filterCriteriaMapper;
     private MimeMessageBuilder mimeMessageBuilder;
+    private GmailMessageMapper gmailMessageMapper;
     private GmailBuddyProperties properties;
     private GmailBuddyProperties.Send send;
     private GmailService gmailService;
@@ -44,11 +51,13 @@ class GmailServiceTest {
         gmailQueryBuilder = mock(GmailQueryBuilder.class);
         filterCriteriaMapper = mock(FilterCriteriaMapper.class);
         mimeMessageBuilder = mock(MimeMessageBuilder.class);
+        gmailMessageMapper = mock(GmailMessageMapper.class);
         properties = mock(GmailBuddyProperties.class);
         send = mock(GmailBuddyProperties.Send.class);
         when(properties.send()).thenReturn(send);
         when(send.maxTotalPayloadSize()).thenReturn(DataSize.ofMegabytes(25));
-        gmailService = new GmailService(gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder, properties);
+        gmailService = new GmailService(gmailRepository, gmailQueryBuilder, filterCriteriaMapper,
+                mimeMessageBuilder, gmailMessageMapper, properties);
     }
 
     @Test
@@ -599,5 +608,221 @@ class GmailServiceTest {
         verify(gmailQueryBuilder).query("label:Inbox");
         verify(gmailQueryBuilder).negatedQuery("label:Spam");
         verify(gmailRepository).deleteMessagesByFilterCriteria(userId, expectedQuery);
+    }
+
+    // =========================================================================
+    // T009 — listDrafts() and getDraft() service method tests
+    // =========================================================================
+
+    @Test
+    @DisplayName("listDrafts() should return DraftListResult from repository on success")
+    void listDrafts_success_returnsDraftListResult() throws IOException {
+        String userId = "test-user";
+        DraftListResult expected = new DraftListResult(List.of(), null, null);
+        when(gmailRepository.listDrafts(userId, null, 25)).thenReturn(expected);
+
+        DraftListResult result = gmailService.listDrafts(userId, null, 25);
+
+        assertThat(result).isEqualTo(expected);
+        verify(gmailRepository).listDrafts(userId, null, 25);
+    }
+
+    @Test
+    @DisplayName("listDrafts() should wrap IOException as GmailApiException")
+    void listDrafts_ioException_throwsGmailApiException() throws IOException {
+        String userId = "test-user";
+        IOException ioException = new IOException("API failure");
+        when(gmailRepository.listDrafts(userId, null, 25)).thenThrow(ioException);
+
+        GmailApiException ex = assertThrows(GmailApiException.class,
+                () -> gmailService.listDrafts(userId, null, 25));
+
+        assertThat(ex.getMessage()).contains("Failed to list drafts for user: test-user");
+        assertThat(ex.getCause()).isEqualTo(ioException);
+    }
+
+    @Test
+    @DisplayName("getDraft() should return DraftDetailResult from repository on success")
+    void getDraft_success_returnsDraftDetailResult() throws IOException {
+        String userId = "test-user";
+        String draftId = "draft-abc123";
+        DraftDetailResult expected = new DraftDetailResult(
+                draftId, "msg-1", null, List.of(), List.of(), List.of(),
+                null, null, null, "text", null, List.of()
+        );
+        when(gmailRepository.getDraft(userId, draftId)).thenReturn(expected);
+
+        DraftDetailResult result = gmailService.getDraft(userId, draftId);
+
+        assertThat(result).isEqualTo(expected);
+        verify(gmailRepository).getDraft(userId, draftId);
+    }
+
+    @Test
+    @DisplayName("getDraft() should propagate ResourceNotFoundException from repository")
+    void getDraft_resourceNotFoundException_propagates() throws IOException {
+        String userId = "test-user";
+        String draftId = "draft-not-found";
+        ResourceNotFoundException notFound = new ResourceNotFoundException("Draft not found");
+        when(gmailRepository.getDraft(userId, draftId)).thenThrow(notFound);
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> gmailService.getDraft(userId, draftId));
+    }
+
+    @Test
+    @DisplayName("getDraft() should wrap IOException as GmailApiException")
+    void getDraft_ioException_throwsGmailApiException() throws IOException {
+        String userId = "test-user";
+        String draftId = "draft-abc";
+        IOException ioException = new IOException("Timeout");
+        when(gmailRepository.getDraft(userId, draftId)).thenThrow(ioException);
+
+        GmailApiException ex = assertThrows(GmailApiException.class,
+                () -> gmailService.getDraft(userId, draftId));
+
+        assertThat(ex.getCause()).isEqualTo(ioException);
+    }
+
+    // =========================================================================
+    // T022 — deleteDraft() service method tests
+    // =========================================================================
+
+    @Test
+    @DisplayName("deleteDraft() should delegate to repository and return void on success")
+    void deleteDraft_success_doesNotThrow() throws IOException {
+        String userId = "test-user";
+        String draftId = "draft-del-001";
+        doNothing().when(gmailRepository).deleteDraft(userId, draftId);
+
+        assertDoesNotThrow(() -> gmailService.deleteDraft(userId, draftId));
+        verify(gmailRepository).deleteDraft(userId, draftId);
+    }
+
+    @Test
+    @DisplayName("deleteDraft() should propagate ResourceNotFoundException from repository")
+    void deleteDraft_resourceNotFoundException_propagates() throws IOException {
+        String userId = "test-user";
+        String draftId = "draft-not-found";
+        ResourceNotFoundException notFound = new ResourceNotFoundException("Not found");
+        doThrow(notFound).when(gmailRepository).deleteDraft(userId, draftId);
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> gmailService.deleteDraft(userId, draftId));
+    }
+
+    @Test
+    @DisplayName("deleteDraft() should wrap IOException as GmailApiException")
+    void deleteDraft_ioException_throwsGmailApiException() throws IOException {
+        String userId = "test-user";
+        String draftId = "draft-del-io";
+        IOException ioException = new IOException("Network error");
+        doThrow(ioException).when(gmailRepository).deleteDraft(userId, draftId);
+
+        GmailApiException ex = assertThrows(GmailApiException.class,
+                () -> gmailService.deleteDraft(userId, draftId));
+
+        assertThat(ex.getCause()).isEqualTo(ioException);
+    }
+
+    // =========================================================================
+    // T032 — updateDraft() service method tests
+    // =========================================================================
+
+    @Test
+    @DisplayName("updateDraft() should return updated DraftDetailResult on success")
+    void updateDraft_success_returnsUpdatedDraftDetailResult() throws Exception {
+        String userId = "test-user";
+        String draftId = "draft-upd-001";
+        SendMessageDTO dto = mock(SendMessageDTO.class);
+        when(dto.inReplyToMessageId()).thenReturn(null);
+        when(dto.to()).thenReturn(List.of("to@example.com"));
+        when(dto.cc()).thenReturn(List.of());
+        when(dto.bcc()).thenReturn(List.of());
+        when(dto.attachments()).thenReturn(List.of());
+        when(dto.subject()).thenReturn("Subject");
+        when(dto.body()).thenReturn("Body text");
+
+        jakarta.mail.internet.MimeMessage mimeMessage = mock(jakarta.mail.internet.MimeMessage.class);
+        when(mimeMessageBuilder.build(eq(dto), eq(null))).thenReturn(mimeMessage);
+
+        DraftCreationResult updateResult = new DraftCreationResult(draftId, "msg-upd-1", null);
+        when(gmailRepository.updateDraft(userId, draftId, mimeMessage)).thenReturn(updateResult);
+
+        DraftDetailResult detailResult = new DraftDetailResult(
+                draftId, "msg-upd-1", null, List.of("to@example.com"), List.of(), List.of(),
+                "Subject", null, "Body text", "text", null, List.of()
+        );
+        when(gmailRepository.getDraft(userId, draftId)).thenReturn(detailResult);
+
+        DraftDetailResult result = gmailService.updateDraft(userId, draftId, dto);
+
+        assertThat(result).isEqualTo(detailResult);
+        verify(gmailRepository).updateDraft(userId, draftId, mimeMessage);
+        verify(gmailRepository).getDraft(userId, draftId);
+    }
+
+    @Test
+    @DisplayName("updateDraft() should propagate ResourceNotFoundException from repository")
+    void updateDraft_resourceNotFoundException_propagates() throws Exception {
+        String userId = "test-user";
+        String draftId = "draft-not-found";
+        SendMessageDTO dto = mock(SendMessageDTO.class);
+        when(dto.inReplyToMessageId()).thenReturn(null);
+        when(dto.to()).thenReturn(List.of("to@example.com"));
+        when(dto.cc()).thenReturn(List.of());
+        when(dto.bcc()).thenReturn(List.of());
+        when(dto.attachments()).thenReturn(List.of());
+        when(dto.subject()).thenReturn("S");
+        when(dto.body()).thenReturn("B");
+
+        jakarta.mail.internet.MimeMessage mimeMessage = mock(jakarta.mail.internet.MimeMessage.class);
+        when(mimeMessageBuilder.build(eq(dto), eq(null))).thenReturn(mimeMessage);
+
+        ResourceNotFoundException notFound = new ResourceNotFoundException("Draft not found");
+        when(gmailRepository.updateDraft(userId, draftId, mimeMessage)).thenThrow(notFound);
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> gmailService.updateDraft(userId, draftId, dto));
+    }
+
+    @Test
+    @DisplayName("updateDraft() with threading should perform lookup before update")
+    void updateDraft_withInReplyToMessageId_performsLookupFirst() throws Exception {
+        String userId = "test-user";
+        String draftId = "draft-threaded";
+        String replyToId = "original-msg-id";
+        SendMessageDTO dto = mock(SendMessageDTO.class);
+        when(dto.inReplyToMessageId()).thenReturn(replyToId);
+        when(dto.to()).thenReturn(List.of("to@example.com"));
+        when(dto.cc()).thenReturn(List.of());
+        when(dto.bcc()).thenReturn(List.of());
+        when(dto.attachments()).thenReturn(List.of());
+        when(dto.subject()).thenReturn("Re: Subject");
+        when(dto.body()).thenReturn("Reply body");
+
+        OriginalMessageLookup lookup = new OriginalMessageLookup(replyToId, "thread-1", "<msg-id@mail.gmail.com>");
+        when(gmailRepository.getMessageHeaders(userId, replyToId)).thenReturn(lookup);
+
+        jakarta.mail.internet.MimeMessage mimeMessage = mock(jakarta.mail.internet.MimeMessage.class);
+        when(mimeMessageBuilder.build(eq(dto), eq(lookup))).thenReturn(mimeMessage);
+
+        DraftCreationResult updateResult = new DraftCreationResult(draftId, "msg-1", "thread-1");
+        when(gmailRepository.updateDraft(userId, draftId, mimeMessage)).thenReturn(updateResult);
+
+        DraftDetailResult detailResult = new DraftDetailResult(
+                draftId, "msg-1", "thread-1", List.of("to@example.com"), List.of(), List.of(),
+                "Re: Subject", null, "Reply body", "text", replyToId, List.of()
+        );
+        when(gmailRepository.getDraft(userId, draftId)).thenReturn(detailResult);
+
+        DraftDetailResult result = gmailService.updateDraft(userId, draftId, dto);
+
+        // Verify lookup happened BEFORE the update
+        var inOrder = inOrder(gmailRepository);
+        inOrder.verify(gmailRepository).getMessageHeaders(userId, replyToId);
+        inOrder.verify(gmailRepository).updateDraft(userId, draftId, mimeMessage);
+
+        assertThat(result.inReplyToMessageId()).isEqualTo(replyToId);
     }
 }

--- a/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceThreadingTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/service/GmailServiceThreadingTest.java
@@ -6,6 +6,7 @@ import com.aucontraire.gmailbuddy.exception.GmailApiException;
 import com.aucontraire.gmailbuddy.exception.OriginalMessageNotFoundException;
 import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
 import com.aucontraire.gmailbuddy.mapper.FilterCriteriaMapper;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.repository.GmailRepository;
 import jakarta.mail.Session;
 import jakarta.mail.internet.MimeMessage;
@@ -76,7 +77,8 @@ class GmailServiceThreadingTest {
         when(properties.send()).thenReturn(send);
         when(send.maxTotalPayloadSize()).thenReturn(DataSize.ofMegabytes(25));
         gmailService = new GmailService(
-                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder, properties);
+                gmailRepository, gmailQueryBuilder, filterCriteriaMapper, mimeMessageBuilder,
+                mock(GmailMessageMapper.class), properties);
     }
 
     // -------------------------------------------------------------------------

--- a/src/test/java/com/aucontraire/gmailbuddy/validation/ControllerValidationTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/validation/ControllerValidationTest.java
@@ -3,6 +3,7 @@ package com.aucontraire.gmailbuddy.validation;
 import com.aucontraire.gmailbuddy.controller.GmailController;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaDTO;
 import com.aucontraire.gmailbuddy.dto.FilterCriteriaWithLabelsDTO;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
 import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
 import com.aucontraire.gmailbuddy.ratelimit.RateLimitService;
@@ -61,6 +62,9 @@ class ControllerValidationTest {
 
     @MockitoBean
     private GmailQuotaEstimator gmailQuotaEstimator;
+
+    @MockitoBean
+    private GmailMessageMapper gmailMessageMapper;
 
     @Test
     @WithMockUser

--- a/src/test/java/com/aucontraire/gmailbuddy/validation/SendMessageValidationTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/validation/SendMessageValidationTest.java
@@ -3,6 +3,7 @@ package com.aucontraire.gmailbuddy.validation;
 import com.aucontraire.gmailbuddy.controller.GmailController;
 import com.aucontraire.gmailbuddy.dto.SendMessageDTO;
 import com.aucontraire.gmailbuddy.fixture.SendMessageRequestFixtures;
+import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
 import com.aucontraire.gmailbuddy.mapper.ResponseMapper;
 import com.aucontraire.gmailbuddy.ratelimit.GmailQuotaEstimator;
 import com.aucontraire.gmailbuddy.ratelimit.RateLimitService;
@@ -80,6 +81,9 @@ class SendMessageValidationTest {
 
     @MockitoBean
     private GmailQuotaEstimator gmailQuotaEstimator;
+
+    @MockitoBean
+    private GmailMessageMapper gmailMessageMapper;
 
     // -------------------------------------------------------------------------
     // Recipient list — empty / missing


### PR DESCRIPTION
## Summary

Completes the drafts CRUD surface (R-005) by adding the missing read/delete/update operations. TJS can now build a drafts review queue without bypassing gmail-buddy.

**4 new REST endpoints**:
- `GET /api/v1/gmail/drafts` — paginated list (default 25, max 50; per-item enrichment via `users.drafts.get`)
- `GET /api/v1/gmail/drafts/{id}` — full `DraftDetailResponse` (recipients, subject, body, threading, attachment metadata; no binary content)
- `DELETE /api/v1/gmail/drafts/{id}` — hard delete, returns 204 No Content
- `PUT /api/v1/gmail/drafts/{id}` — full replace via `SendMessageDTO` (PUT-replaces semantics; no partial update)

**Reuses PR #16 infrastructure**: `MimeMessageBuilder`, `GmailMessageMapper`, `RateLimitInterceptor`, `GmailQuotaEstimator`, all existing exception types (`ResourceNotFoundException`, `GmailApiException`, `ServiceUnavailableException`, `RateLimitException`, `InvalidRecipientException`, `MessageTooLargeException`, `ValidationException`, `OriginalMessageNotFoundException`), `mapGmailSendError` helper. **No new dependencies, no new exception types, no new ProblemType URIs.**

**Version**: `0.3.0-SNAPSHOT` → `0.4.0-SNAPSHOT` (semver MINOR — backward-compatible additions)

## Production bug fixes uncovered

1. **`ResponseHeaderFilter` on 204 responses** — header-emission was hooked off stream I/O which never fires for empty-body responses, so DELETE responses were missing `X-Gmail-Quota-Used` and `X-RateLimit-*` headers. Fixed with `responseWrapper.flushBuffer()` after \`chain.doFilter()\`. Surfaced by the new \`DraftsRateLimitHeadersIntegrationTest\` — exactly the kind of issue the integration test was designed to catch.

2. **Draft path-variable `@Pattern` regex too narrow** — original \`[0-9a-fA-F]{1,32}\` (matching message-ID format) rejected real Gmail-issued draft IDs like \`r9068706262700056809\` (letter prefix outside hex). Broadened to \`[A-Za-z0-9_-]{1,128}\` for draft path variables only — \`messageId\`/\`threadId\`/\`inReplyToMessageId\` retain hex regex (those ARE hex). Discovered during smoke testing.

## Quota cost (per FR-019, emitted in \`X-Gmail-Quota-Used\` header)

| Endpoint | Cost |
|---|---|
| \`GET /drafts\` | \`1 + N*5\` units (1 list + 5 per item enriched) |
| \`GET /drafts/{id}\` | 5 units |
| \`DELETE /drafts/{id}\` | 10 units |
| \`PUT /drafts/{id}\` | 15 units (no threading) or 20 units (with \`inReplyToMessageId\` lookup) |

## Test plan

- [x] **Unit tests**: 1385 / 0 / 0 (1302 baseline + 83 new across all phases)
- [x] **Integration tests**: \`DraftLifecycleIntegrationTest\` (FR-001a verification: sent draft absent from list; analogous for delete) and \`DraftsRateLimitHeadersIntegrationTest\` (FR-019/FR-019a header propagation across all 4 endpoints + 5xx error paths)
- [x] **Coverage** (\`./mvnw clean test jacoco:report\`): overall 79% (no regression vs baseline); new \`dto/response\` records 100%; new code paths in mapper/quota/service/repo ≥85% per SC-006
- [x] **Smoke tested manually** against real Gmail account (T046):
  - [x] \`GET /drafts\` → 200 with populated \`results\`+\`nextPageToken\`+\`totalCount\`; \`X-Gmail-Quota-Used: 1+N*5\`
  - [x] \`GET /drafts/{id}\` → 200 with full \`DraftDetailResponse\`; \`X-Gmail-Quota-Used: 5\`
  - [x] \`PUT /drafts/{id}\` → 200 with updated DraftDetailResponse; PUT-replaces semantics confirmed (omitted optional fields like \`cc\`/\`bcc\`/\`attachments\`/\`threading\` cleared in post-update state per Edge Cases); \`X-Gmail-Quota-Used: 15\`
  - [x] \`DELETE /drafts/{id}\` → 204 No Content with full \`X-RateLimit-*\` + \`X-Gmail-Quota-Used: 10\` headers (validating the ResponseHeaderFilter fix above)
- [x] **OpenAPI**: all 4 endpoints render in Swagger UI with \`@Operation\`, \`@ApiResponses\`, and \`@Schema\` annotations on response DTOs (verified via \`grep\` — 28 \`@Schema\` annotations across 4 records; 105 \`@ApiResponses\` blocks across controller)
- [x] **Logging discipline (FR-020/FR-021)**: \`grep\` confirms no draft body content, recipient addresses, subject text, or attachment filenames in any log statement from the new code paths
- [x] **Regression (FR-024)**: full v0.3.0 send/draft/messages test suite still passes (\`POST /drafts\`, \`POST /drafts/{id}/send\`, \`POST /messages\`, \`POST /messages/filter\`, \`DELETE /messages/filter\`, \`POST /messages/filter/modifyLabels\`, \`GET /messages/{id}/body\`, \`PUT /messages/{id}/read\`)
- [x] **Postman collection** updated with 4 new endpoint examples in the "Send & Draft" folder (matching \`quickstart.md\` recipes)

## Out of scope (deferred to local roadmap)

- **R-022** (LOWER): convert \`MessageListResult\` from class to record for consistency with new \`DraftListResult\`. Anti-Slop §A3: don't do as standalone cosmetic PR — fold into next pagination touch.
- **R-023** (HIGH, elevated post-audit): extract Gmail ID regexes into custom Bean Validation annotations (\`@GmailDraftId\`, \`@GmailMessageId\`, etc.) AND close validation gaps on 4+ pre-existing path variables that have NO \`@Pattern\` at all (\`getMessage\`/\`deleteMessage\`/\`markAsRead\`/\`POST /drafts/{id}/send\` — the audit revealed real path-traversal exposure). Best candidate trigger: feature 004 (Read API completeness — R-016+R-017+R-018+R-019).

## Architectural notes

- **Spec-kit flow**: \`/speckit-specify\` → \`/speckit-clarify\` → \`/speckit-plan\` → \`/speckit-checklist\` (api.md, 43 items, all checked) → \`/spec-gaps\` (7 items resolved) → \`/speckit-tasks\` (48 tasks) → \`/speckit-analyze\` (8 issues) → \`/reconcile\` (all addressed) → \`/speckit-implement\` (47/48 complete; T046 smoke test completed manually post-implementation).
- **Constitution compliance**: all 8 principles + Anti-Slop A1–A4/B/C/D verified PASS at plan and post-design gates. \`GmailRepository\` interface methods return domain types (\`DraftListResult\`, \`DraftDetailResult\`, \`DraftCreationResult\`, \`void\`); no Gmail SDK types in service/controller layer signatures (Constitution II).