### PR TITLE
chore: extract Gmail ID regexes into custom annotations + close validation gaps (R-023)

### DIFF
--- a/src/main/java/com/aucontraire/gmailbuddy/controller/GmailController.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/controller/GmailController.java
@@ -15,6 +15,8 @@ import com.aucontraire.gmailbuddy.dto.response.DraftListResponse;
 import com.aucontraire.gmailbuddy.dto.response.DraftResponse;
 import com.aucontraire.gmailbuddy.dto.response.LabelModificationResponse;
 import com.aucontraire.gmailbuddy.dto.response.SendMessageResponse;
+import com.aucontraire.gmailbuddy.validation.GmailDraftId;
+import com.aucontraire.gmailbuddy.validation.GmailMessageId;
 import com.aucontraire.gmailbuddy.dto.response.MessageListResponse;
 import com.aucontraire.gmailbuddy.dto.response.MessageSummary;
 import com.aucontraire.gmailbuddy.mapper.GmailMessageMapper;
@@ -39,7 +41,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -259,7 +260,7 @@ public class GmailController {
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<DeleteOperationResult> deleteMessage(
             @Parameter(description = "The ID of the message to delete", required = true)
-            @PathVariable String messageId) {
+            @PathVariable @GmailMessageId String messageId) {
         long startTime = System.currentTimeMillis();
         String userId = properties.gmailApi().defaultUserId();
 
@@ -370,7 +371,7 @@ public class GmailController {
     @GetMapping(value = "/messages/{messageId}/body", produces = MediaType.TEXT_HTML_VALUE)
     public ResponseEntity<String> getMessageBody(
             @Parameter(description = "The ID of the message", required = true)
-            @PathVariable String messageId) {
+            @PathVariable @GmailMessageId String messageId) {
         long startTime = System.currentTimeMillis();
         String userId = properties.gmailApi().defaultUserId();
 
@@ -405,7 +406,7 @@ public class GmailController {
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<LabelModificationResponse> markMessageAsRead(
             @Parameter(description = "The ID of the message to mark as read", required = true)
-            @PathVariable String messageId) {
+            @PathVariable @GmailMessageId String messageId) {
         String userId = properties.gmailApi().defaultUserId();
         BulkOperationResult result = gmailService.markMessageAsRead(userId, messageId);
 
@@ -519,7 +520,7 @@ public class GmailController {
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<SendMessageResponse> sendDraft(
             @Parameter(description = "The Gmail-assigned draft identifier returned by POST /drafts", required = true)
-            @PathVariable String draftId) {
+            @PathVariable @GmailDraftId String draftId) {
 
         String userId = properties.gmailApi().defaultUserId();
 
@@ -670,7 +671,7 @@ public class GmailController {
     @GetMapping(value = "/drafts/{draftId}", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<DraftDetailResponse> getDraft(
             @Parameter(description = "The Gmail-assigned draft identifier", required = true)
-            @PathVariable @Pattern(regexp = "[A-Za-z0-9_-]{1,128}") String draftId) {
+            @PathVariable @GmailDraftId String draftId) {
 
         String userId = properties.gmailApi().defaultUserId();
         DraftDetailResult result = gmailService.getDraft(userId, draftId);
@@ -710,7 +711,7 @@ public class GmailController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public ResponseEntity<Void> deleteDraft(
             @Parameter(description = "The Gmail-assigned draft identifier", required = true)
-            @PathVariable @Pattern(regexp = "[A-Za-z0-9_-]{1,128}") String draftId) {
+            @PathVariable @GmailDraftId String draftId) {
 
         String userId = properties.gmailApi().defaultUserId();
         gmailService.deleteDraft(userId, draftId);
@@ -759,7 +760,7 @@ public class GmailController {
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<DraftDetailResponse> updateDraft(
             @Parameter(description = "The Gmail-assigned draft identifier", required = true)
-            @PathVariable @Pattern(regexp = "[A-Za-z0-9_-]{1,128}") String draftId,
+            @PathVariable @GmailDraftId String draftId,
             @Valid @RequestBody SendMessageDTO dto,
             HttpServletRequest request) {
 

--- a/src/main/java/com/aucontraire/gmailbuddy/dto/SendMessageDTO.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/dto/SendMessageDTO.java
@@ -1,5 +1,6 @@
 package com.aucontraire.gmailbuddy.dto;
 
+import com.aucontraire.gmailbuddy.validation.GmailMessageId;
 import com.aucontraire.gmailbuddy.validation.MaxBodySize;
 import com.aucontraire.gmailbuddy.validation.NoHeaderInjection;
 import com.aucontraire.gmailbuddy.validation.OptionalEmail;
@@ -95,7 +96,7 @@ public record SendMessageDTO(
         nullable = true,
         example = "1976a4bc3fe89d0c"
     )
-    @Pattern(regexp = "[0-9a-fA-F]{1,32}")
+    @GmailMessageId
     String threadId,
 
     /**
@@ -118,7 +119,7 @@ public record SendMessageDTO(
         nullable = true,
         example = "1976a4bc3fe89d0c"
     )
-    @Pattern(regexp = "[0-9a-fA-F]{1,32}")
+    @GmailMessageId
     String inReplyToMessageId,
 
     /**

--- a/src/main/java/com/aucontraire/gmailbuddy/validation/GmailDraftId.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/validation/GmailDraftId.java
@@ -1,0 +1,70 @@
+package com.aucontraire.gmailbuddy.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.ReportAsSingleViolation;
+import jakarta.validation.constraints.Pattern;
+import java.lang.annotation.*;
+
+/**
+ * Constraint annotation that validates a Gmail draft identifier.
+ *
+ * <p>Gmail draft IDs are opaque alphanumeric strings using a letter-prefix +
+ * digits format (e.g., {@code r9068706262700056809}) — distinct from Gmail
+ * <strong>message</strong> IDs which are short hex (e.g., {@code 1976a4bc3fe89d0c}).
+ * The accepted character set is {@code [A-Za-z0-9_-]} with a maximum length of
+ * 128 characters: permissive enough for Gmail's actual draft ID format,
+ * restrictive enough to reject path-traversal characters ({@code /}, {@code .},
+ * whitespace, etc.) and oversized inputs.</p>
+ *
+ * <p>This is a <strong>composed constraint</strong>: the meta-annotation
+ * {@link Pattern} is automatically processed by Hibernate Validator, so no
+ * dedicated {@code GmailDraftIdValidator} class is required (Constitution
+ * Anti-Slop §A2 — no unnecessary abstractions). The
+ * {@link ReportAsSingleViolation} annotation ensures only a single violation
+ * message is surfaced when the constraint fails.</p>
+ *
+ * <p>Originally, draft IDs and message IDs both used the same hex regex
+ * ({@code [0-9a-fA-F]{1,32}}). That assumption was wrong for drafts —
+ * discovered during smoke testing the {@code GET /api/v1/gmail/drafts/{id}}
+ * endpoint when a real Gmail-issued ID {@code r9068706262700056809} was
+ * rejected by the validator. See ROADMAP R-023 and feature 003 spec.</p>
+ *
+ * <p>Null values are treated as valid — presence enforcement is the
+ * responsibility of {@link jakarta.validation.constraints.NotBlank} or
+ * {@link jakarta.validation.constraints.NotNull}, not this constraint.</p>
+ *
+ * <p>The {@code TYPE_USE} target enables per-element annotation on generic type
+ * arguments, e.g. {@code List<@GmailDraftId String>}.</p>
+ *
+ * @see GmailMessageId
+ */
+@Documented
+@Pattern(regexp = "[A-Za-z0-9_-]{1,128}")
+@ReportAsSingleViolation
+@Constraint(validatedBy = {})
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GmailDraftId {
+
+    /**
+     * Violation message returned when the constraint is not satisfied.
+     *
+     * @return the error message template
+     */
+    String message() default "must be a valid Gmail draft identifier (alphanumeric, hyphen, or underscore; max 128 characters)";
+
+    /**
+     * Validation groups this constraint belongs to.
+     *
+     * @return the groups
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * Payload for extensibility by constraint consumers.
+     *
+     * @return the payload
+     */
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/main/java/com/aucontraire/gmailbuddy/validation/GmailMessageId.java
+++ b/src/main/java/com/aucontraire/gmailbuddy/validation/GmailMessageId.java
@@ -1,0 +1,70 @@
+package com.aucontraire.gmailbuddy.validation;
+
+import jakarta.validation.Constraint;
+import jakarta.validation.Payload;
+import jakarta.validation.ReportAsSingleViolation;
+import jakarta.validation.constraints.Pattern;
+import java.lang.annotation.*;
+
+/**
+ * Constraint annotation that validates a Gmail short hex identifier — used for
+ * message IDs, thread IDs, and the {@code inReplyToMessageId} reference.
+ *
+ * <p>Gmail message and thread IDs are opaque hex strings up to 32 characters
+ * (e.g., {@code 1976a4bc3fe89d0c}). The accepted character set is
+ * {@code [0-9a-fA-F]} with a maximum length of 32 characters. This is the
+ * same regex applied to {@code SendMessageDTO.threadId} and
+ * {@code SendMessageDTO.inReplyToMessageId} fields, and to {@code messageId}
+ * path variables on the messages endpoints.</p>
+ *
+ * <p>This annotation is intentionally separate from {@link GmailDraftId} —
+ * draft IDs use a different format (letter-prefix + alphanumeric, see
+ * {@link GmailDraftId} javadoc). Conflating the two regexes was the original
+ * source of the validation bug fixed in feature 003 (PR #17); this annotation
+ * pair makes the two formats explicit at the call site.</p>
+ *
+ * <p>This is a <strong>composed constraint</strong>: the meta-annotation
+ * {@link Pattern} is automatically processed by Hibernate Validator, so no
+ * dedicated {@code GmailMessageIdValidator} class is required (Constitution
+ * Anti-Slop §A2 — no unnecessary abstractions). The
+ * {@link ReportAsSingleViolation} annotation ensures only a single violation
+ * message is surfaced when the constraint fails.</p>
+ *
+ * <p>Null values are treated as valid — presence enforcement is the
+ * responsibility of {@link jakarta.validation.constraints.NotBlank} or
+ * {@link jakarta.validation.constraints.NotNull}, not this constraint.</p>
+ *
+ * <p>The {@code TYPE_USE} target enables per-element annotation on generic type
+ * arguments, e.g. {@code List<@GmailMessageId String>}.</p>
+ *
+ * @see GmailDraftId
+ */
+@Documented
+@Pattern(regexp = "[0-9a-fA-F]{1,32}")
+@ReportAsSingleViolation
+@Constraint(validatedBy = {})
+@Target({ElementType.FIELD, ElementType.PARAMETER, ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GmailMessageId {
+
+    /**
+     * Violation message returned when the constraint is not satisfied.
+     *
+     * @return the error message template
+     */
+    String message() default "must be a valid Gmail short hex identifier (hex characters; max 32 characters)";
+
+    /**
+     * Validation groups this constraint belongs to.
+     *
+     * @return the groups
+     */
+    Class<?>[] groups() default {};
+
+    /**
+     * Payload for extensibility by constraint consumers.
+     *
+     * @return the payload
+     */
+    Class<? extends Payload>[] payload() default {};
+}

--- a/src/test/java/com/aucontraire/gmailbuddy/controller/GmailControllerTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/controller/GmailControllerTest.java
@@ -469,4 +469,44 @@ public class GmailControllerTest {
                         .with(csrf()))
                 .andExpect(status().isBadGateway());
     }
+
+    // ---------------------------------------------------------------------------
+    // R-023 gap-fill: pre-existing path variables that previously had no @Pattern
+    // validation now reject malformed IDs at the controller layer (HTTP 400)
+    // before the request reaches the service. Uses "bad.id" — period is URL-safe
+    // (passes through URI parsing) but rejected by both [0-9a-fA-F]{1,32} and
+    // [A-Za-z0-9_-]{1,128}.
+    // ---------------------------------------------------------------------------
+
+    @Test
+    public void deleteMessage_400ForMalformedMessageId() throws Exception {
+        mockMvc.perform(delete("/api/v1/gmail/messages/{messageId}", "bad.id")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void getMessageBody_400ForMalformedMessageId() throws Exception {
+        mockMvc.perform(get("/api/v1/gmail/messages/{messageId}/body", "bad.id")
+                        .accept(MediaType.TEXT_HTML)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void markMessageAsRead_400ForMalformedMessageId() throws Exception {
+        mockMvc.perform(put("/api/v1/gmail/messages/{messageId}/read", "bad.id")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    public void sendDraft_400ForMalformedDraftId() throws Exception {
+        mockMvc.perform(post("/api/v1/gmail/drafts/{draftId}/send", "bad.id")
+                        .accept(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest());
+    }
 }

--- a/src/test/java/com/aucontraire/gmailbuddy/integration/ApiClientAuthenticationIntegrationTest.java
+++ b/src/test/java/com/aucontraire/gmailbuddy/integration/ApiClientAuthenticationIntegrationTest.java
@@ -120,7 +120,7 @@ class ApiClientAuthenticationIntegrationTest {
         void shouldAuthenticateAndAccessSpecificGmailMessageEndpoint() throws Exception {
             // Given
             mockValidTokenResponse();
-            String messageId = "1a2b3c4d5e6f7g8h";
+            String messageId = "1a2b3c4d5e6f7890"; // valid hex per @GmailMessageId
 
             // When & Then
             mockMvc.perform(get(API_BASE_PATH + "/messages/" + messageId + "/body")
@@ -325,7 +325,7 @@ class ApiClientAuthenticationIntegrationTest {
         void shouldDisableCsrfForApiPutRequestsWithValidBearerToken() throws Exception {
             // Given
             mockValidTokenResponse();
-            String messageId = "1a2b3c4d5e6f7g8h";
+            String messageId = "1a2b3c4d5e6f7890"; // valid hex per @GmailMessageId
 
             // When & Then - PUT request should work without CSRF token
             mockMvc.perform(put(API_BASE_PATH + "/messages/" + messageId + "/read")


### PR DESCRIPTION
## Summary

Two-part validation hardening (R-023):

1. **Reuse**: Extract the duplicated `@Pattern(regexp = "...")` regexes for Gmail draft IDs and short hex message IDs into composed Bean Validation annotations (`@GmailDraftId`, `@GmailMessageId`) so a future regex change is one file edit, not a multi-site sweep.
2. **Hardening**: Add `@Pattern` validation to 4 pre-existing path variables that previously had **none** — real path-traversal exposure points where any string would be passed straight through to the Gmail API.

The two parts are bundled because a focused validation-hardening PR is easier to review than splitting the work, and Anti-Slop §A3 ("no cosmetic-only PRs") requires the substantive gap-fill work to justify the annotation extraction.

## Changes

**New annotation files** (composed constraints — `@Pattern` is auto-processed as meta-annotation by Hibernate Validator, so no `ConstraintValidator` class is needed; satisfies Anti-Slop §A2 "no unnecessary abstractions"):
- \`@GmailDraftId\` — wraps \`[A-Za-z0-9_-]{1,128}\` (Gmail's opaque draft ID format with letter prefix, e.g., \`r9068706262700056809\`)
- \`@GmailMessageId\` — wraps \`[0-9a-fA-F]{1,32}\` (Gmail short hex IDs; used for messageId, threadId, inReplyToMessageId)

**Sweep — 5 inline `@Pattern` replacements**:
- \`GmailController\` × 3: \`getDraft\`, \`deleteDraft\`, \`updateDraft\` path params (from PR #17)
- \`SendMessageDTO\` × 2: \`threadId\`, \`inReplyToMessageId\` fields

**Sweep — 4 missing-validation gap-fills** (real path-traversal exposure points — these accepted any string before this PR):
- \`GmailController.deleteMessage\` (\`DELETE /messages/{messageId}\`) — added \`@GmailMessageId\`
- \`GmailController.getMessageBody\` (\`GET /messages/{messageId}/body\`) — added \`@GmailMessageId\`
- \`GmailController.markMessageAsRead\` (\`PUT /messages/{messageId}/read\`) — added \`@GmailMessageId\`
- \`GmailController.sendDraft\` (\`POST /drafts/{draftId}/send\`, from PR #16) — added \`@GmailDraftId\`

## Latent bug surfaced during this work

\`ApiClientAuthenticationIntegrationTest\` was sending \`\"1a2b3c4d5e6f7g8h\"\` as a "valid" message ID — but \`g\` and \`h\` are NOT hex characters. The missing \`@Pattern\` validation on those endpoints had been masking the typo since PR #11. Fixed to use real hex \`\"1a2b3c4d5e6f7890\"\`.

This is **exactly the class of bug R-023 is designed to prevent** — a typo in a test data string that wasn't caught because the production code didn't enforce the contract. Filed as additional motivation for **R-024** (TestIds constants class — local roadmap, LOWER tier) which would centralize ID literals across the test suite to make typos like this impossible.

## Test plan

- [x] **Unit + integration tests**: 1389 / 0 / 0 (was 1385 / 0 / 0 at v0.4.0; +4 new gap-fill tests)
- [x] **New tests** (\`GmailControllerTest\`):
  - \`deleteMessage_400ForMalformedMessageId\` (uses \`bad.id\` — period rejected by hex regex)
  - \`getMessageBody_400ForMalformedMessageId\`
  - \`markMessageAsRead_400ForMalformedMessageId\`
  - \`sendDraft_400ForMalformedDraftId\` (uses \`bad.id\` — period rejected by alphanumeric regex)
- [x] **Coverage**: overall 79% (no regression vs baseline). New annotations don't appear in JaCoCo (annotations have no executable code; only the meta-annotated \`@Pattern\` runs at validation time, which is part of jakarta.validation, not our code). Validation **behavior** is exercised by the 4 new tests + the 7 existing controller tests inherited from PR #17 (\`getDraft_400ForNonHexDraftId\`, \`deleteDraft_400ForInvalidDraftId\`, \`updateDraft_400ForInvalidDraftId\`, plus success-path tests on the same endpoints).
- [x] **Latent bug fix verified**: \`ApiClientAuthenticationIntegrationTest$SuccessfulApiAuthenticationTests.shouldAuthenticateAndAccessSpecificGmailMessageEndpoint\` and \`$CsrfProtectionTests.shouldDisableCsrfForApiPutRequestsWithValidBearerToken\` both pass after fixing the test ID (they failed against the new \`@GmailMessageId\` validator until the typo was corrected).

## Constitution alignment

- **Anti-Slop §A2** (no unnecessary abstractions) — satisfied: composed annotations avoid creating a one-line \`ConstraintValidator\` class. The annotations are reuse-driven type-level definitions matching the existing project pattern (\`@SafeFilename\`, \`@ValidMimeType\`, \`@ValidBase64\`, \`@NoHeaderInjection\`).
- **Anti-Slop §A3** (no cosmetic-only changes) — satisfied: this PR isn't cosmetic. It closes 4 real path-traversal exposure points where the production code accepted any string for the path variable.
- **Constitution III** (DTO & API Contract Hygiene) — preserved: no DTO shape changes; \`SendMessageDTO\` field types and external API contract unchanged.
- **Constitution VIII** (Testing Architecture) — preserved: new tests follow Arrange-Act-Assert with descriptive method names matching the project pattern.

## Out of scope (deferred to local roadmap)

- **R-024** (LOWER): centralize test ID constants in a \`TestIds\` support class — would have prevented the \`1a2b3c4d5e6f7g8h\` typo. Opportunistic per Anti-Slop §A3 — apply when touching test files for other reasons; not a standalone cosmetic sweep.
- Future Gmail-ID annotations as the API surface grows: \`@GmailLabelId\` (R-018), \`@GmailAttachmentId\` (R-019), \`@GmailFilterId\` (R-021), \`@GmailHistoryId\`, \`@GmailSendAsAlias\` (R-002). All flagged in R-023's body for feature 004 to pick up.

No version bump (incremental hardening, not a new feature). Branch builds on \`v0.4.0\` (master).